### PR TITLE
design: 회원가입 UI 구현

### DIFF
--- a/src/app/(route)/join/_components/UserHobbyForm.tsx
+++ b/src/app/(route)/join/_components/UserHobbyForm.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import CategorySelector from '@/app/_components/categorySelector'
+
+export default function UserHobbyForm() {
+  return (
+    <>
+      <p className="font-[600]">대표 취미</p>
+      <CategorySelector />
+      <div className="mt-[36px]">
+        <p className="mb-[16px] font-[600]">취미 경력</p>
+        <select
+          className="h-[48px] w-full rounded-[4px] border border-[#BDBDBD] bg-white px-[12px] text-[16px]"
+          defaultValue="없음"
+          required
+        >
+          <option value="" disabled>
+            경력을 선택하세요
+          </option>
+          <option value="none">없음</option>
+          <option value="1year">1년</option>
+          <option value="2years">2년</option>
+          <option value="3years">3년</option>
+          <option value="5years">5년 이상</option>
+          <option value="10years">10년 이상</option>
+        </select>
+      </div>
+      <div className="h-[148px]">
+        <button
+          className="mt-[119px] flex h-[48px] w-[436px] items-center justify-center rounded-[4px] bg-black font-[600] text-white"
+          type="submit"
+        >
+          회원가입
+        </button>
+      </div>
+    </>
+  )
+}

--- a/src/app/(route)/join/_components/UserInfoForm.tsx
+++ b/src/app/(route)/join/_components/UserInfoForm.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+export default function UserInfoForm() {
+  return (
+    <>
+      <div className="w-[436px]">
+        <label htmlFor="nickname" className="font-[600]">
+          닉네임
+        </label>
+        <div className="mt-[16px]">
+          <input
+            id="nickname"
+            placeholder="닉네임을 입력해 주세요."
+            className="mr-[16px] h-[48px] w-[324px] rounded-[4px] border border-[#BDBDBD] px-[12px] outline-0"
+          />
+          <button
+            className="h-[48px] w-[96px] cursor-pointer rounded-[4px] bg-black font-[600] text-white"
+            type="button"
+          >
+            중복확인
+          </button>
+        </div>
+      </div>
+      <div className="mt-[36px]">
+        <label htmlFor="aboutMe" className="font-[600]">
+          자기소개
+        </label>
+        <textarea
+          id="aboutMe"
+          placeholder="자기소개를 입력해 주세요."
+          className="mt-[16px] h-[140px] w-[436px] resize-none rounded-[4px] border border-[#BDBDBD] px-[12px] pt-[14px] outline-0"
+        />
+      </div>
+      <div className="mt-[36px]">
+        <label htmlFor="mbti" className="font-[600]">
+          MBTI
+        </label>
+        <input
+          id="mbti"
+          placeholder="MBTI를 입력해 주세요."
+          className="mt-[16px] h-[48px] w-[436px] rounded-[4px] border border-[#BDBDBD] px-[12px] outline-0"
+        />
+      </div>
+      <div className="h-[148px]">
+        <button
+          className="mt-[119px] flex h-[48px] w-[436px] items-center justify-center rounded-[4px] bg-black font-[600] text-white"
+          type="button"
+        >
+          다음
+        </button>
+      </div>
+    </>
+  )
+}

--- a/src/app/(route)/join/page.tsx
+++ b/src/app/(route)/join/page.tsx
@@ -10,6 +10,7 @@ export default function JoinPage() {
         <p className="mb-[10px] text-[26px] font-[700]">Lime</p>
         <h1 className="mb-[69px] text-[30px] font-[600]">프로필 작성</h1>
         <UserInfoForm />
+        {/* 임시 주석 처리 */}
         {/* <UserHobbyForm /> */}
       </form>
     </main>

--- a/src/app/(route)/join/page.tsx
+++ b/src/app/(route)/join/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import UserInfoForm from './_components/UserInfoForm'
+import UserHobbyForm from './_components/UserHobbyForm'
 
 export default function JoinPage() {
   return (
@@ -9,6 +10,7 @@ export default function JoinPage() {
         <p className="mb-[10px] text-[26px] font-[700]">Lime</p>
         <h1 className="mb-[69px] text-[30px] font-[600]">프로필 작성</h1>
         <UserInfoForm />
+        {/* <UserHobbyForm /> */}
       </form>
     </main>
   )

--- a/src/app/(route)/join/page.tsx
+++ b/src/app/(route)/join/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import UserInfoForm from './_components/UserInfoForm'
+
+export default function JoinPage() {
+  return (
+    <main className="min-h-screen bg-[#F7F7F7]">
+      <form className="mx-auto w-[610px] bg-white px-[87px] pt-[71px]">
+        <p className="mb-[10px] text-[26px] font-[700]">Lime</p>
+        <h1 className="mb-[69px] text-[30px] font-[600]">프로필 작성</h1>
+        <UserInfoForm />
+      </form>
+    </main>
+  )
+}

--- a/src/app/(route)/join/page.tsx
+++ b/src/app/(route)/join/page.tsx
@@ -5,8 +5,8 @@ import UserHobbyForm from './_components/UserHobbyForm'
 
 export default function JoinPage() {
   return (
-    <main className="min-h-screen bg-[#F7F7F7]">
-      <form className="mx-auto w-[610px] bg-white px-[87px] pt-[71px]">
+    <main className="h-dvh bg-[#F7F7F7]">
+      <form className="mx-auto h-full w-[610px] bg-white px-[87px] pt-[71px]">
         <p className="mb-[10px] text-[26px] font-[700]">Lime</p>
         <h1 className="mb-[69px] text-[30px] font-[600]">프로필 작성</h1>
         <UserInfoForm />

--- a/src/app/_components/categorySelector/index.tsx
+++ b/src/app/_components/categorySelector/index.tsx
@@ -28,16 +28,16 @@ export default function CategorySelector() {
         const items = categories[categoryGroup as keyof Categories]
         return (
           <React.Fragment key={categoryGroup}>
-            <p className="mt-8 text-[18px] font-[800]">{categoryGroup}</p>
+            <p className="mt-8 text-[14px] font-[400]">{categoryGroup}</p>
             <div className="flex flex-wrap">
               {items.map((item) => (
                 <label
                   key={item}
-                  className={`my-4 mr-6 inline-block cursor-pointer rounded-full border px-5 py-1 font-medium ${
+                  className={`my-3 mr-6 inline-block h-[32px] cursor-pointer rounded-[40px] border px-5 py-1 font-[500] font-medium ${
                     selected.item === item &&
                     selected.category === categoryGroup
                       ? 'border-black'
-                      : 'border-[#DADADA] text-[#898989]'
+                      : 'border-[#BDBDBD] text-[#BDBDBD]'
                   }`}
                 >
                   <input


### PR DESCRIPTION
## 1. Changes

- 회원가입 페이지 UI 구현 - `회원가입-1`, `회원가입-2`

## 2. Screenshot

### 회원가입-1

![image](https://github.com/uju-in/lime-frontend/assets/114549939/f40bd763-12d4-4e20-bb70-d5fc3703b4cf)

### 회원가입-2

![image](https://github.com/uju-in/lime-frontend/assets/114549939/ecb0d179-2574-4999-a5b1-2f6a78e618f0)


## 3. Issues

## 4. To Reviewer

@yeeeerim 

- 회원가입-1, 회원가입-2 분기를 아직 나누지는 않고 주석으로 처리해 놓았습니다. 이 부분은 구현 시 세부적으로 정하도록 하겠습니다.!
- 취미 경력의 경우 임시로 select로 구현해 놓았습니다.
- 마찬가지로 UI 구현인 관계로 그냥 Merge 해주셔도 됩니다!

## 5. Plans

- [ ] - 회원가입 API 연동
