### PR TITLE
feat: 아이템 생성 API 연동

### DIFF
--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -1,12 +1,19 @@
 'use client'
 
 import React, { ChangeEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 import { ItemState } from '@/app/_types/addItem.type'
+
+import useAddItem from '@/app/_hook/api/useAddItem'
 
 import Categories from '../../../../_components/categorySelector'
 
 export default function PostForm() {
+  const router = useRouter()
+
+  const { mutateAsync: addItem } = useAddItem()
+
   const [item, setItem] = useState<ItemState>({
     hobbyValue: '',
     itemUrl: '',
@@ -21,12 +28,25 @@ export default function PostForm() {
     }))
   }
 
+  /** 아이템 등록 */
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    const data = await addItem(item)
+
+    if (data === 200) {
+      router.push('/items')
+    }
+  }
+
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <p className="text-xl font-semibold">
         아이템 추가할 취미를 선택해 주세요.
       </p>
-      <Categories />
+      <Categories
+        setCategory={(hobbyValue) => setItem({ ...item, hobbyValue })}
+      />
       <p className="my-12 text-[18px] font-[600]">
         아이템 추가할 URL을 입력하세요
       </p>

--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -1,8 +1,26 @@
-import React from 'react'
+'use client'
+
+import React, { ChangeEvent, useState } from 'react'
+
+import { ItemState } from '@/app/_types/addItem.type'
 
 import Categories from '../../../../_components/categorySelector'
 
 export default function PostForm() {
+  const [item, setItem] = useState<ItemState>({
+    hobbyValue: '',
+    itemUrl: '',
+  })
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+
+    setItem((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }))
+  }
+
   return (
     <form>
       <p className="text-xl font-semibold">
@@ -12,7 +30,11 @@ export default function PostForm() {
       <p className="my-12 text-[18px] font-[600]">
         아이템 추가할 URL을 입력하세요
       </p>
-      <input className="h-[40px] w-[720px] rounded-[2px] border border-[#DADADA] p-1 focus:outline-none" />
+      <input
+        name="itemUrl"
+        className="h-[40px] w-[720px] rounded-[2px] border border-[#DADADA] p-1 focus:outline-none"
+        onChange={handleChange}
+      />
       <div className=" mt-[70px] flex justify-center">
         <button
           className="h-[45px] w-[250px] rounded-[2px] bg-black text-[15px] text-white"

--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -17,7 +17,7 @@ export default function PostForm() {
   const { mutateAsync: addItem } = useAddItem()
 
   const [item, setItem] = useState<ItemState>({
-    hobbyValue: '',
+    hobbyName: '',
     itemUrl: '',
   })
 
@@ -53,7 +53,7 @@ export default function PostForm() {
         아이템 추가할 취미를 선택해 주세요.
       </p>
       <Categories
-        setCategory={(hobbyValue) => setItem({ ...item, hobbyValue })}
+        setCategory={(hobbyName) => setItem({ ...item, hobbyName })}
       />
       <p className="my-12 text-[18px] font-[600]">
         아이템 추가할 URL을 입력하세요

--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -9,19 +9,11 @@ export default function PostForm() {
         아이템 추가할 취미를 선택해 주세요.
       </p>
       <Categories />
-      <p className="mb-6 mt-12 text-[18px] font-[800px]">
+      <p className="my-12 text-[18px] font-[600]">
         아이템 추가할 URL을 입력하세요
       </p>
-      <div className="flex  w-[690px] justify-between">
-        <input className="h-[40px] w-[600px] rounded-[2px] border border-[#DADADA] p-1 focus:outline-none" />
-        <button
-          className="h-[40px] w-[65px] rounded-[2px] bg-black text-[15px] text-white"
-          type="button"
-        >
-          입력
-        </button>
-      </div>
-      <div className=" mt-[65px] flex justify-center">
+      <input className="h-[40px] w-[720px] rounded-[2px] border border-[#DADADA] p-1 focus:outline-none" />
+      <div className=" mt-[70px] flex justify-center">
         <button
           className="h-[45px] w-[250px] rounded-[2px] bg-black text-[15px] text-white"
           type="submit"

--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -7,6 +7,8 @@ import { ItemState } from '@/app/_types/addItem.type'
 
 import useAddItem from '@/app/_hook/api/useAddItem'
 
+import { validateUrl } from '../_utils/validation'
+
 import Categories from '../../../../_components/categorySelector'
 
 export default function PostForm() {
@@ -31,6 +33,12 @@ export default function PostForm() {
   /** 아이템 등록 */
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+
+    const isValid = validateUrl(item.itemUrl)
+
+    if (!isValid) {
+      return
+    }
 
     const data = await addItem(item)
 

--- a/src/app/(route)/items/add-item/_utils/validation.ts
+++ b/src/app/(route)/items/add-item/_utils/validation.ts
@@ -1,0 +1,15 @@
+/* url 검증 - 다나와, 네이버, 쿠팡만 허용 */
+const validateUrl = (url: string) => {
+  const urlPattern =
+    /^(https?:\/\/)?(www\.)?(shopping\.naver\.com|prod\.danawa\.com|coupang\.com)/
+
+  if (!urlPattern.test(url)) {
+    alert('쿠팡, 네이버 쇼핑, 다나와만 사용 가능합니다!')
+
+    return false
+  }
+
+  return true
+}
+
+export { validateUrl }

--- a/src/app/(route)/items/add-item/_utils/validation.ts
+++ b/src/app/(route)/items/add-item/_utils/validation.ts
@@ -1,10 +1,10 @@
 /* url 검증 - 다나와, 네이버, 쿠팡만 허용 */
 const validateUrl = (url: string) => {
   const urlPattern =
-    /^(https?:\/\/)?(www\.)?(shopping\.naver\.com|prod\.danawa\.com|coupang\.com)/
+    /^(https?:\/\/)?(www\.)?(shopping\.naver\.com|prod\.danawa\.com|coupang\.com|smartstore\.naver.com)/
 
   if (!urlPattern.test(url)) {
-    alert('쿠팡, 네이버 쇼핑, 다나와만 사용 가능합니다!')
+    alert('사용 가능한 URL을 입력해 주세요.')
 
     return false
   }

--- a/src/app/(route)/items/add-item/page.tsx
+++ b/src/app/(route)/items/add-item/page.tsx
@@ -2,7 +2,7 @@ import PostForm from './_component/PostForm'
 
 export default function AddItemPage() {
   return (
-    <section className="w-[850px] flex-col bg-white px-8">
+    <section className="w-[780px] flex-col bg-white px-8">
       <div className="flex flex h-[150px] items-center">
         <h1 className="text-[32px] font-bold">아이템 생성</h1>
       </div>

--- a/src/app/(route)/items/add-item/page.tsx
+++ b/src/app/(route)/items/add-item/page.tsx
@@ -1,3 +1,4 @@
+import RQProvider from '@/app/_components/RQProvider'
 import PostForm from './_component/PostForm'
 
 export default function AddItemPage() {
@@ -6,7 +7,9 @@ export default function AddItemPage() {
       <div className="flex flex h-[150px] items-center">
         <h1 className="text-[32px] font-bold">아이템 생성</h1>
       </div>
-      <PostForm />
+      <RQProvider>
+        <PostForm />
+      </RQProvider>
     </section>
   )
 }

--- a/src/app/_hook/api/useAddItem.ts
+++ b/src/app/_hook/api/useAddItem.ts
@@ -1,0 +1,37 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { ItemState } from '@/app/_types/addItem.type'
+
+async function postAddItem(params: ItemState) {
+  const accessToken = localStorage.getItem('accessToken')
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/enroll`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(params),
+    },
+  )
+
+  if (!res.ok) {
+    throw new Error('에러!!')
+  }
+
+  return res.status
+}
+
+export default function useAddItem() {
+  return useMutation<number, unknown, ItemState>({
+    mutationFn: postAddItem,
+    onSuccess: () => {
+      alert('아이템 등록 성공!')
+    },
+    onError: () => {
+      alert('아이템 등록 실패')
+    },
+  })
+}

--- a/src/app/_hook/api/useAddItem.ts
+++ b/src/app/_hook/api/useAddItem.ts
@@ -17,8 +17,10 @@ async function postAddItem(params: ItemState) {
     },
   )
 
+  const data = await res.json()
+
   if (!res.ok) {
-    throw new Error('에러!!')
+    throw data.message
   }
 
   return res.status
@@ -30,8 +32,8 @@ export default function useAddItem() {
     onSuccess: () => {
       alert('아이템 등록 성공!')
     },
-    onError: () => {
-      alert('아이템 등록 실패')
+    onError: (error) => {
+      alert(error)
     },
   })
 }

--- a/src/app/_types/addItem.type.ts
+++ b/src/app/_types/addItem.type.ts
@@ -1,4 +1,4 @@
 export interface ItemState {
-  hobbyValue: string
+  hobbyName: string
   itemUrl: string
 }

--- a/src/app/_types/addItem.type.ts
+++ b/src/app/_types/addItem.type.ts
@@ -1,0 +1,4 @@
+export interface ItemState {
+  hobbyValue: string
+  itemUrl: string
+}


### PR DESCRIPTION
## 1. Changes

- 아이템 등록 API 연동

## 2. Screenshot

## 3. Issues

1. 1차적으로 쿠팡, 네이버 쇼핑( + 스토어), 다나와 도메인을 검증하는 정규 표현식을 추가했습니다.

## 4. To Reviewer

- @yeeeerim 
- 지난 회원가입 API 연동 pr과 비슷한 로직이라 큰 차이는 없을 것 같아서 확인해 보시고 따로 코멘트해 주실 부분이 없다면 merge 해주셔도 됩니다!

## 5. Plans

- [ ] - 아이템 상세 페이지 API 연동
