### PR TITLE
feat: 리뷰 등록 모달 API 연동

### DIFF
--- a/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
+++ b/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
@@ -1,19 +1,85 @@
 'use client'
 
-import Modal from '@/app/_components/modal'
+import React, { ChangeEvent, useRef, useState } from 'react'
 import Image from 'next/image'
-import React from 'react'
+
+import Modal from '@/app/_components/modal'
+import useAddReview from '@/app/_hook/api/useAddReview'
+import StarRatingFormatter from './StarRatingFormatter'
+
+import { validateForm } from '../_utils/validation'
 
 interface PropsType {
   setShowReviewModal: React.Dispatch<React.SetStateAction<boolean>>
 }
 
+interface ReviewFormState {
+  rating: number
+  content: string
+  multipartReviewImages: File[]
+}
+
 export default function ReviewModal(props: PropsType) {
   const { setShowReviewModal } = props
 
+  const InputRef = useRef<HTMLInputElement>(null)
+
+  const [review, setReview] = useState<ReviewFormState>({
+    rating: 0,
+    content: '',
+    multipartReviewImages: [],
+  })
+
+  const { mutateAsync: addReview } = useAddReview()
+
+  /** 별점, 본문, 이미지 업로드 관련 */
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const target = e.target as HTMLInputElement
+    const { name, value, files, type } = target
+
+    if (type === 'file' && files) {
+      const filesList = Array.from(files) as File[]
+
+      setReview((prevState) => ({
+        ...prevState,
+        multipartReviewImages: filesList,
+      }))
+    } else {
+      setReview((prevState) => ({
+        ...prevState,
+        [name]: value,
+      }))
+    }
+  }
+
+  /** 리뷰 등록 */
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (!validateForm(review)) {
+      return
+    }
+
+    const formData = new FormData()
+
+    review.multipartReviewImages.forEach((file) => {
+      formData.append('multipartReviewImages', file)
+    })
+    formData.append('rating', review.rating.toString())
+    formData.append('content', review.content)
+
+    const status = await addReview({ itemId: 160, formData })
+
+    if (status === 200) {
+      setShowReviewModal(false)
+    }
+  }
+
   return (
     <Modal>
-      <div className="p-[13px_0_45px]">
+      <form className="p-[13px_0_45px]" onSubmit={handleSubmit}>
         <div className="flex justify-between border-b px-[23px] py-[18px]">
           <div className="w-[36px]" />
           <div className="w-full text-center text-[24px]">리뷰작성</div>
@@ -46,67 +112,62 @@ export default function ReviewModal(props: PropsType) {
           <div className="mb-[50px] flex flex-col items-center gap-[20px]">
             <div>상품은 만족하셨나요?</div>
             <div className="flex gap-[8px]">
-              <Image
-                alt="star"
-                width={56}
-                height={56}
-                src="/image/icon/icon-empty_star.svg"
-              />
-              <Image
-                alt="star"
-                width={56}
-                height={56}
-                src="/image/icon/icon-empty_star.svg"
-              />
-              <Image
-                alt="star"
-                width={56}
-                height={56}
-                src="/image/icon/icon-empty_star.svg"
-              />
-              <Image
-                alt="star"
-                width={56}
-                height={56}
-                src="/image/icon/icon-empty_star.svg"
-              />
-              <Image
-                alt="star"
-                width={56}
-                height={56}
-                src="/image/icon/icon-empty_star.svg"
+              {/** 리뷰 별점 입력 */}
+              <StarRatingFormatter
+                rating={review.rating}
+                setRate={(rating) => setReview({ ...review, rating })}
               />
             </div>
           </div>
           <div className="flex flex-col items-center gap-[20px]">
             <div>리뷰글을 작성해주세요.</div>
             <textarea
+              name="content"
               placeholder="최소 10자 이상 작성해주세요."
               className="h-[152px] w-[508px] max-w-full resize-none border border-[#DADADA] bg-[#F4F4F4] p-[14px_12px] text-[14px] outline-none"
+              onChange={handleChange}
+              minLength={10}
+              required
             />
             <button
               type="button"
+              onClick={() => {
+                if (InputRef.current) {
+                  InputRef.current.click()
+                }
+              }}
               className="w-full border border-dashed border-[#DADADA] py-[11px]"
             >
               사진 첨부하기
             </button>
+            <input
+              name="multipartReviewImages"
+              type="file"
+              multiple
+              ref={InputRef}
+              className="hidden"
+              onChange={handleChange}
+            />
           </div>
           <div className="mt-[50px] flex w-full gap-[20px] text-[16px] font-semibold">
             <button
               type="button"
               className="flex-1 rounded-[4px] border border-[#DADADA] py-[12px]"
+              onClick={() => {
+                setShowReviewModal(false)
+              }}
             >
               취소
             </button>
             <button
-              type="button"
+              type="submit"
               className="flex-1 rounded-[4px] bg-black py-[12px] text-white"
             >
               등록
             </button>
           </div>
         </div>
-      </div>
+      </form>
     </Modal>
   )
 }

--- a/src/app/(route)/items/[itemID]/_component/StarRatingFormatter.tsx
+++ b/src/app/(route)/items/[itemID]/_component/StarRatingFormatter.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+
+interface PropsType {
+  rating: number
+  setRate: (value: number) => void
+}
+
+const TOTAL_STAR = 5
+
+export default function StarRatingFormatter(props: PropsType) {
+  const { rating, setRate } = props
+
+  const handleStarClick = (starIndex: number) => {
+    setRate(starIndex + 1)
+  }
+
+  return (
+    <>
+      {[...Array(TOTAL_STAR)].map((_, i) => (
+        <Image
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          src={`/image/icon/icon-${i < rating ? 'filled' : 'empty'}_star.svg`}
+          alt="star"
+          width={56}
+          height={56}
+          className="cursor-pointer"
+          onClick={() => handleStarClick(i)}
+          aria-label="rating start"
+        />
+      ))}
+    </>
+  )
+}

--- a/src/app/(route)/items/[itemID]/_component/StarRatingFormatter.tsx
+++ b/src/app/(route)/items/[itemID]/_component/StarRatingFormatter.tsx
@@ -19,16 +19,18 @@ export default function StarRatingFormatter(props: PropsType) {
 
   return (
     <>
-      {[...Array(TOTAL_STAR)].map((_, i) => (
+      {[...Array(TOTAL_STAR)].map((_, index) => (
         <Image
           // eslint-disable-next-line react/no-array-index-key
-          key={i}
-          src={`/image/icon/icon-${i < rating ? 'filled' : 'empty'}_star.svg`}
+          key={index}
+          src={`/image/icon/icon-${
+            index < rating ? 'filled' : 'empty'
+          }_star.svg`}
           alt="star"
           width={56}
           height={56}
           className="cursor-pointer"
-          onClick={() => handleStarClick(i)}
+          onClick={() => handleStarClick(index)}
           aria-label="rating start"
         />
       ))}

--- a/src/app/(route)/items/[itemID]/_utils/validation.ts
+++ b/src/app/(route)/items/[itemID]/_utils/validation.ts
@@ -1,0 +1,22 @@
+/* 이미지 별점 선택 검증 */
+export const validateForm = ({
+  rating,
+  multipartReviewImages,
+}: {
+  rating: number
+  multipartReviewImages: File[]
+}) => {
+  if (rating === 0) {
+    alert('별점을 선택해 주세요!')
+
+    return false
+  }
+
+  if (multipartReviewImages.length === 0) {
+    alert('리뷰 사진을 첨부해 주세요.')
+
+    return false
+  }
+
+  return true
+}

--- a/src/app/(route)/items/[itemID]/page.tsx
+++ b/src/app/(route)/items/[itemID]/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 
+import RQProvider from '@/app/_components/RQProvider'
 import Review from './_component/Review'
 import ReviewModal from './_component/ReviewModal'
 
@@ -118,7 +119,9 @@ export default function DetailPage() {
         </div>
       </article>
       {showReviewModal && (
-        <ReviewModal setShowReviewModal={setShowReviewModal} />
+        <RQProvider>
+          <ReviewModal setShowReviewModal={setShowReviewModal} />
+        </RQProvider>
       )}
     </section>
   )

--- a/src/app/(route)/items/add-item/_component/PostForm.tsx
+++ b/src/app/(route)/items/add-item/_component/PostForm.tsx
@@ -63,6 +63,9 @@ export default function PostForm() {
         className="h-[40px] w-[720px] rounded-[2px] border border-[#DADADA] p-1 focus:outline-none"
         onChange={handleChange}
       />
+      <p className="mt-[8px] text-[14px] font-[400] text-[#A4A4A4]">
+        *네이버 쇼핑, 쿠팡, 다나와 URL만 입력 가능합니다.
+      </p>
       <div className=" mt-[70px] flex justify-center">
         <button
           className="h-[45px] w-[250px] rounded-[2px] bg-black text-[15px] text-white"

--- a/src/app/_hook/api/useAddReview.ts
+++ b/src/app/_hook/api/useAddReview.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query'
+
+interface AddReviewRequest {
+  itemId: number
+  formData: FormData
+}
+
+async function postAddReview({ itemId, formData }: AddReviewRequest) {
+  const accessToken = localStorage.getItem('accessToken')
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/${itemId}/reviews`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: formData,
+    },
+  )
+
+  const data = await res.json()
+
+  if (!res.ok) {
+    throw data.message
+  }
+
+  return res.status
+}
+
+export default function useAddReview() {
+  return useMutation<number, Error, AddReviewRequest>({
+    mutationFn: ({ itemId, formData }) => postAddReview({ itemId, formData }),
+    onSuccess: () => {
+      alert('리뷰 등록 성공!')
+    },
+    onError: (error) => {
+      alert(error)
+    },
+  })
+}


### PR DESCRIPTION
## 1. Changes

- 리뷰 작성 API 연동

<br/>

## 2. Screenshot

![화면-기록-2024-01-29-오후-6 21 48](https://github.com/mintmin0320/COMMA_REFACTORING/assets/114549939/c4b2771f-08ed-40c3-9673-a648f85bab10)

<br/>

![스크린샷 2024-01-29 오후 6 38 14](https://github.com/uju-in/lime-frontend/assets/114549939/03392e42-87a8-485c-aeec-b2a5485956bb)

## 3. Issues

1. 리뷰 상단 - 아이템 정보 연동

<div align="center">

![image](https://github.com/uju-in/lime-frontend/assets/114549939/1b13a476-1ae6-47be-974c-ce5b1328e1cf)

</div>

- 표시한 부분은, 우선 내용을 병합하고 아이템 상세 페이지 브랜치에서 관련 로직을 연동하는 작업 진행 예정입니다!
- `const status = await addReview({ itemId: 160, formData })` itemId 값도 변경할 예정입니다!

<br/>

2.`StarRatingFormatter` 컴포넌트

- eslint 규칙을 부분적으로 해제했습니다
Image 태그에 map 함수를 적용하는 과정에서 key 값을 index로 적용했습니다.

<br/>

## 4. To Reviewer

@yeeeerim 
앞서 언급한 부분을 제외하고는 기능 구현을 마친 상태입니다. 
변경 사항이 있다면, 코멘트 부탁드립니다~

<br/>

## 5. Plans

- [ ] - 투표 UI 
