### PR TITLE
refactor: 토큰 저장 방식 변경(localStorage -> cookie)

### DIFF
--- a/src/app/_components/GetSearchParams.tsx
+++ b/src/app/_components/GetSearchParams.tsx
@@ -11,7 +11,6 @@ export function GetSearchParams() {
   useEffect(() => {
     if (token) {
       setCookie('accessToken', token)
-      localStorage.setItem('accessToken', token)
     }
   }, [token])
 

--- a/src/app/_components/GetSearchParams.tsx
+++ b/src/app/_components/GetSearchParams.tsx
@@ -3,15 +3,17 @@
 import React, { useEffect } from 'react'
 
 import useGetSearchParam from '../_hook/common/useGetSearchParams'
+import { setCookie } from '../_utils/cookie'
 
 export function GetSearchParams() {
-  const accessToken = useGetSearchParam('accessToken')
+  const token = useGetSearchParam('accessToken')
 
   useEffect(() => {
-    if (accessToken) {
-      localStorage.setItem('accessToken', accessToken)
+    if (token) {
+      setCookie('accessToken', token)
+      localStorage.setItem('accessToken', token)
     }
-  }, [])
+  }, [token])
 
-  return <div>GetSearchParams</div>
+  return <div>쿠키 저장 임시 로직</div>
 }

--- a/src/app/_utils/cookie.ts
+++ b/src/app/_utils/cookie.ts
@@ -1,0 +1,11 @@
+'use server'
+
+import { cookies } from 'next/headers'
+
+export const setCookie = (key: string, value: string) => {
+  cookies().set(key, value)
+}
+
+export const getCookie = (key: string): any => {
+  return cookies().get(key)?.value
+}


### PR DESCRIPTION
## 1. Changes

기존 localstorage에 토큰을 저장하는 방식에서 next에 내장된 `cookies`를 사용해 쿠키로 저장합니다.

<br/>

## 2. Screenshot

-

## 3. Issues

### 사용 방법
 _utils > cookie.ts 파일에서 get,set 함수 호출
- ex) `const accessToken = await getCookie('accessToken')`

- 'use server' 키워드가 필요한 관계로 따로 파일을 분리했습니다.
- cookie()는 반환된 값을 미리 알 수 없는 동적 함수 -> 비동기 처리(async, await) 처리가 필요합니다. 데이터 페칭 함수 내부에서 정상 동작합니다.


<br/>

## 4. To Reviewer

@yeeeerim 
현재 Suspense, Streaming과 함께 사용하는 과정에서는 에러가 발생하지만, 사용하지 않을 경우 정상 동작합니다.
추후에 로직 수정 시 큰 작업 소요가 없을 것 같아 해결 전까지 사용해도 좋을 것 같습니다.

<br/>

## 5. Plans
