### PR TITLE
refactor: clsx, tailwind-merge 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.17.12",
     "@tanstack/react-query-devtools": "^5.17.12",
+    "clsx": "^2.1.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-config-prettier": "^9.1.0",
@@ -20,7 +21,8 @@
     "prettier": "^3.1.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-intersection-observer": "^9.8.0"
+    "react-intersection-observer": "^9.8.0",
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(route)/items/[itemID]/_component/Review.tsx
+++ b/src/app/(route)/items/[itemID]/_component/Review.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import useOutsideClick from '@/app/_hook/common/useOutsideClick'
 
 import { ReviewResponse } from '@/app/_types/review.type'
+import { cn } from '@/app/_utils/twMerge'
 
 import useReviewLikeAction from '@/app/_hook/api/useReviewLikeAction'
 import { dateFormatter } from '../_utils/dateFormatter'
@@ -74,13 +75,13 @@ export default function Review(props: PropsType) {
   return (
     <div
       ref={dropdownRef}
-      className={`flex w-full justify-between ${
-        isFirst ? 'border-0' : 'border-t border-[#D2D2D2]'
-      } ${
-        showReviewDetail === reviewSummary.reviewId
-          ? 'mb-[12px] bg-[#F6F6F6]'
-          : 'h-[190px] items-center bg-[#fff]'
-      } p-[20px] hover:bg-[#f6f6f6]`}
+      className={cn('flex w-full justify-between p-[20px] hover:bg-[#f6f6f6]', {
+        'border-0': isFirst,
+        'border-t border-[#D2D2D2]': !isFirst,
+        'mb-[12px] bg-[#F6F6F6]': showReviewDetail === reviewSummary.reviewId,
+        'h-[190px] items-center bg-[#fff]':
+          showReviewDetail !== reviewSummary.reviewId,
+      })}
       onClick={handleReviewClick}
     >
       <div className="mr-[20px] flex w-[535px] flex-col p-[20px]">
@@ -136,19 +137,22 @@ export default function Review(props: PropsType) {
         {/** 리뷰 좋아요 */}
         <button
           type="button"
-          className={`ml-[38px] mt-[8px] flex h-[30px] w-[50px] items-center justify-center rounded-[100px] ${
-            reviewLoginMemberStatus.isLiked
-              ? 'bg-[#000] text-[#fff]'
-              : 'text-[#6F6F6F]'
-          } ${showReviewDetail && 'border border-[#D1D1D1]'}`}
+          className={cn(
+            'ml-[38px] mt-[8px] flex h-[30px] w-[50px] items-center justify-center rounded-[100px]',
+            {
+              'bg-[#000] text-[#fff]': reviewLoginMemberStatus.isLiked,
+              'text-[#6F6F6F]': !reviewLoginMemberStatus.isLiked,
+              'border border-[#D1D1D1]': showReviewDetail,
+            },
+          )}
           onClick={handleLikeClick}
         >
           <Image
-            src={`${
+            src={
               reviewLoginMemberStatus.isLiked
                 ? '/image/icon/icon-like_border_white.svg'
                 : '/image/icon/icon-like.svg'
-            }`}
+            }
             alt="recommend"
             width={14}
             height={14}

--- a/src/app/(route)/items/[itemID]/_component/ReviewSection.tsx
+++ b/src/app/(route)/items/[itemID]/_component/ReviewSection.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { ItemInfo, ReviewResponse, SortOption } from '@/app/_types/review.type'
 
 import { useSearchItemQuery } from '@/app/_hook/api/useSearchItemQuery'
+import { cn } from '@/app/_utils/twMerge'
 
 import Review from './Review'
 import ReviewModal from './ReviewModal'
@@ -60,11 +61,10 @@ export default function ReviewSection({ itemInfo }: ItemInfo) {
                 )}
                 <button
                   type="button"
-                  className={`${
-                    sortOption === option.value
-                      ? 'text-[#000]'
-                      : 'text-[#BCBCBC]'
-                  }`}
+                  className={cn({
+                    'text-[#000]': sortOption === option.value,
+                    'text-[#100d0d]': sortOption !== option.value,
+                  })}
                   onClick={() => setSortOption(option.value)}
                 >
                   {option.label}

--- a/src/app/(route)/items/_components/SideMenu.tsx
+++ b/src/app/(route)/items/_components/SideMenu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import useGetSearchParam from '@/app/_hook/common/useGetSearchParams'
 import { CategoryOption } from '@/app/_constants'
 import Link from 'next/link'
+import { cn } from '@/app/_utils/twMerge'
 
 export default function SideMenu() {
   const router = useRouter()
@@ -25,9 +26,10 @@ export default function SideMenu() {
             return (
               <li
                 key={item}
-                className={`text-black ${
-                  item === category ? 'font-bold' : 'font-normal'
-                }`}
+                className={cn('text-black', {
+                  'font-bold': item === category,
+                  'font-normal': item !== category,
+                })}
               >
                 <Link href={`/items?title=${title}&category=${item}`}>
                   {item}

--- a/src/app/(route)/items/_components/SortBox.tsx
+++ b/src/app/(route)/items/_components/SortBox.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from 'react'
 import Image from 'next/image'
 import { SortOption } from '@/app/(route)/items/_constants'
 import useOutsideClick from '@/app/_hook/common/useOutsideClick'
+import { cn } from '@/app/_utils/twMerge'
 
 interface Props {
   sortOption: {
@@ -50,11 +51,10 @@ export default function SortBox(props: Props) {
           {SortOption.map((item) => {
             return (
               <li
-                className={`cursor-pointer hover:text-black ${
-                  sortOption === item
-                    ? 'font-semibold text-black'
-                    : 'font-normal text-[#868585]'
-                }`}
+                className={cn('cursor-pointer hover:text-black', {
+                  'font-semibold text-black': sortOption === item,
+                  'font-normal text-[#868585]': sortOption !== item,
+                })}
                 key={item.value}
                 onClick={() => {
                   setSortOption(item)

--- a/src/app/(route)/join/_components/CareerSelector.tsx
+++ b/src/app/(route)/join/_components/CareerSelector.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 
 import useOutsideClick from '@/app/_hook/common/useOutsideClick'
 
+import { cn } from '@/app/_utils/twMerge'
 import { CareerOption } from '@/app/_types/signUp.types'
 
 import { careerOptions } from '../_constants/careerOptions'
@@ -40,9 +41,10 @@ export default function CareerSelector({ setCareer }: CareerSelectorProps) {
         className="flex h-[48px] w-[436px] items-center justify-between rounded-[4px] border border-[#BDBDBD] px-4"
       >
         <p
-          className={`text-[14px] font-[500] ${
-            careerLabel === '경력 기간 선택' ? 'text-[#BDBDBD]' : 'text-[#000]'
-          }`}
+          className={cn('text-[14px] font-[500]', {
+            'text-[#BDBDBD]': careerLabel === '경력 기간 선택',
+            'text-[#000]': careerLabel !== '경력 기간 선택',
+          })}
         >
           {careerLabel}
         </p>

--- a/src/app/(route)/saves/[folderName]/_component/SaveFolderHeader.tsx
+++ b/src/app/(route)/saves/[folderName]/_component/SaveFolderHeader.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useRef, useState } from 'react'
 import useOutsideClick from '@/app/_hook/common/useOutsideClick'
 import Image from 'next/image'
 import { SavePageMode } from '@/app/_types/save.type'
+import { cn } from '@/app/_utils/twMerge'
 
 const originFolderName = '농구' // TODO
 
@@ -118,7 +119,13 @@ export namespace SaveFolderHeader {
           <button
             type="button"
             disabled={newFolderName.length === 0}
-            className={`w-[90px] rounded-full border-[0.5px] border-[#e2e2e2] py-[7.5px] text-white ${newFolderName.length > 0 ? 'bg-black' : 'bg-[#b1b1b1]'}`}
+            className={cn(
+              'w-[90px] rounded-full border-[0.5px] border-[#e2e2e2] py-[7.5px] text-white',
+              {
+                'bg-black': newFolderName.length > 0,
+                'bg-[#b1b1b1]': newFolderName.length <= 0,
+              },
+            )}
           >
             수정하기
           </button>

--- a/src/app/(route)/saves/_component/AddFolderModal.tsx
+++ b/src/app/(route)/saves/_component/AddFolderModal.tsx
@@ -1,4 +1,5 @@
 import Modal from '@/app/_components/modal'
+import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 import React, { useState } from 'react'
 
@@ -36,7 +37,10 @@ export default function AddFolderModal({ setShowAddFolderModal }: Props) {
             />
             <button
               type="button"
-              className={`rounded-[100px] p-[13px_23px] text-white ${folderName.length > 0 ? 'bg-black' : 'bg-[#B1B1B1]'}`}
+              className={cn('rounded-[100px] p-[13px_23px] text-white', {
+                'bg-black': folderName.length > 0,
+                'bg-[#B1B1B1]': folderName.length <= 0,
+              })}
             >
               만들기
             </button>

--- a/src/app/(route)/saves/_component/SaveFolderGroupItem.tsx
+++ b/src/app/(route)/saves/_component/SaveFolderGroupItem.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/app/_utils/twMerge'
 import React from 'react'
 
 export default function SaveFolderGroupItem({
@@ -9,7 +10,10 @@ export default function SaveFolderGroupItem({
 }) {
   return (
     <div
-      className={`relative mr-5 flex h-[232px] w-[387px] ${disabled ? 'cursor-auto' : 'cursor-pointer'}`}
+      className={cn('relative mr-5 flex h-[232px] w-[387px]', {
+        'cursor-auto': disabled,
+        'cursor-pointer': !disabled,
+      })}
     >
       <div className="z-0 h-[232px] w-[240px] rounded-l-[8.83px] bg-[#BCBCBC]" />
       <div className="z-0">
@@ -19,7 +23,7 @@ export default function SaveFolderGroupItem({
       {disabled && (
         <div className="absolute left-0 top-0 z-20 h-full w-full bg-white opacity-80" />
       )}
-      <div className="bg-gradient-folder absolute left-0 top-0 z-10 h-[193px] w-full rounded-t-[8.83px] pl-4 pt-4">
+      <div className="absolute left-0 top-0 z-10 h-[193px] w-full rounded-t-[8.83px] bg-gradient-folder pl-4 pt-4">
         <p className="text-[20px] font-[700] text-white drop-shadow-[0.774px_0.774px_2.012px_rgba(0,0,0,0.30)]">
           {folderName}
         </p>

--- a/src/app/_components/categorySelector/index.tsx
+++ b/src/app/_components/categorySelector/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/app/_utils/twMerge'
 import React, { useState } from 'react'
 
 interface Categories {
@@ -37,33 +38,38 @@ export default function CategorySelector({
           <React.Fragment key={categoryGroup}>
             <p className="mt-8 text-[14px] font-[400]">{categoryGroup}</p>
             <div className="flex flex-wrap">
-              {items.map((item) => (
-                <label
-                  key={item}
-                  className={`my-3 mr-3 inline-block flex h-[32px] cursor-pointer items-center rounded-[40px] border px-5 text-[12px] font-[500] font-medium ${
-                    selected.item === item &&
-                    selected.category === categoryGroup
-                      ? 'border-black'
-                      : 'border-[#BDBDBD] text-[#BDBDBD]'
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="hobby"
-                    value={item}
-                    checked={
-                      selected.item === item &&
-                      selected.category === categoryGroup
-                    }
-                    onChange={() =>
-                      handleRadioChange(categoryGroup as keyof Categories, item)
-                    }
-                    className="sr-only"
-                    required
-                  />
-                  {item}
-                </label>
-              ))}
+              {items.map((item) => {
+                const checked =
+                  selected.item === item && selected.category === categoryGroup
+                return (
+                  <label
+                    key={item}
+                    className={cn(
+                      'my-3 mr-3 flex h-[32px] cursor-pointer items-center rounded-[40px] border px-5 text-[12px] font-medium',
+                      {
+                        'border-black': checked,
+                        'border-[#BDBDBD] text-[#BDBDBD]': !checked,
+                      },
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="hobby"
+                      value={item}
+                      checked={checked}
+                      onChange={() =>
+                        handleRadioChange(
+                          categoryGroup as keyof Categories,
+                          item,
+                        )
+                      }
+                      className="sr-only"
+                      required
+                    />
+                    {item}
+                  </label>
+                )
+              })}
             </div>
           </React.Fragment>
         )

--- a/src/app/_components/modal/index.tsx
+++ b/src/app/_components/modal/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/app/_utils/twMerge'
 import { ReactNode } from 'react'
 
 type ModalProps = {
@@ -16,9 +17,13 @@ function Modal({ isScrollActive = false, children }: ModalProps) {
     >
       <div
         id="ModalInner"
-        className={`absolute left-[50%] top-[50%] max-h-[90vh] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-[8px] bg-white ${
-          isScrollActive ? 'overflow-scroll' : 'overflow-hidden'
-        }`}
+        className={cn(
+          'absolute left-[50%] top-[50%] max-h-[90vh] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-[8px] bg-white',
+          {
+            'overflow-scroll': isScrollActive,
+            'overflow-hidden': !isScrollActive,
+          },
+        )}
       >
         {children}
       </div>

--- a/src/app/_utils/twMerge.ts
+++ b/src/app/_utils/twMerge.ts
@@ -1,0 +1,7 @@
+import type { ClassValue } from 'clsx'
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@babel/runtime@^7.23.2":
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.23.7":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
@@ -669,6 +669,11 @@ client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -2533,6 +2538,13 @@ synckit@^0.8.6:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
+
+tailwind-merge@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.2.1.tgz#3f10f296a2dba1d88769de8244fafd95c3324aeb"
+  integrity sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==
+  dependencies:
+    "@babel/runtime" "^7.23.7"
 
 tailwindcss@^3.3.0:
   version "3.4.1"


### PR DESCRIPTION
## 1. Changes

-  #19 

## 2. Screenshot

> src/app/_utils/twMerge.ts
```typescript
import type { ClassValue } from 'clsx'
import { clsx } from 'clsx'
import { twMerge } from 'tailwind-merge'

export function cn(...inputs: ClassValue[]) {
  return twMerge(clsx(inputs))
}
```

## 3. Issues
1. 해당 라이브러리를 사용해본 경험이 있는데, 사용하면서 한 가지 이슈가 있었던 것이 있어서 공유드립니다!

```typescript
className={`${ sortOption === option.value
  ? 'text-[#000]'
  : 'text-[#BCBCBC]'
}`}
```

예를 들어 위와 같은 코드를 변경한다고 할 때,

```typescript
className={cn('text-[#BCBCBC]', { 'text-[#000]' : sortOption === option.value })}
```
이렇게 변경해도 원하는대로 동작하는 것처럼 보이는데,
간헐적으로 `text-[#BCBCBC]` 부분이 동작하지 않는 이슈가 발생합니다.
따라서 반드시 아래처럼 작성해주시면 베스트입니다!

```typescript
className={cn({
  'text-[#000]': sortOption === option.value,
  'text-[#100d0d]': sortOption !== option.value,
})}
```

## 4. To Reviewer

- @mintmin0320

`cn()` 공용 함수를 만들어서 tailwind를 사용한 곳 중에서 조건문을 사용하고 있는 곳을 모두 변경하였습니다.
사용법은 280ad3adc7b37896cd4aebc6024cbc2efe764ee0 해당 커밋 작업사항 중 하나 참고해주시면 될 것 같습니다! (기존에 Issue 를 통해 공유드린 방법과 동일합니다.)

## 5. Plans

- [ ] - 찜 목록 API 연동
