### PR TITLE
refactor: 아이템 & 리뷰 API 변경 사항 적용

### DIFF
--- a/src/app/(route)/items/[itemID]/_component/EditButtons.tsx
+++ b/src/app/(route)/items/[itemID]/_component/EditButtons.tsx
@@ -7,16 +7,15 @@ import useDeleteReview from '@/app/_hook/api/useDeleteReview'
 interface PropsType {
   setShowReviewModal: React.Dispatch<React.SetStateAction<boolean>>
   reviewId: number
-  itemId: number
 }
 
-function EditButtons(props: PropsType) {
-  const { setShowReviewModal, reviewId, itemId } = props
+export default function EditButtons(props: PropsType) {
+  const { setShowReviewModal, reviewId } = props
 
   const { mutateAsync: deleteReview } = useDeleteReview()
 
   const handleDeleteReview = async () => {
-    await deleteReview({ itemId, reviewId })
+    await deleteReview(reviewId)
   }
 
   return (
@@ -52,5 +51,3 @@ function EditButtons(props: PropsType) {
     </div>
   )
 }
-
-export default EditButtons

--- a/src/app/(route)/items/[itemID]/_component/Review.tsx
+++ b/src/app/(route)/items/[itemID]/_component/Review.tsx
@@ -59,7 +59,6 @@ export default function Review(props: PropsType) {
     e.stopPropagation()
 
     await likeAction({
-      itemId: itemInfo.id,
       reviewId: reviewSummary.reviewId,
       isLiked: reviewLoginMemberStatus.isLiked,
     })
@@ -178,7 +177,6 @@ export default function Review(props: PropsType) {
             <EditButtons
               setShowReviewModal={setShowReviewModal}
               reviewId={reviewSummary.reviewId}
-              itemId={itemInfo.id}
             />
           )}
         </div>

--- a/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
+++ b/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
@@ -112,6 +112,8 @@ export default function ReviewModal(props: PropsType) {
       reviewItemUrlsToRemove.forEach((imageUrl) => {
         formData.append('reviewItemUrlsToRemove', imageUrl)
       })
+    } else {
+      formData.append('itemId', itemId.toString())
     }
 
     const reviewId = review?.reviewId as number
@@ -127,7 +129,7 @@ export default function ReviewModal(props: PropsType) {
   }
 
   return (
-    <Modal>
+    <Modal isScrollActive>
       <form className="p-[13px_0_45px]" onSubmit={handleSubmit}>
         <div className="flex justify-between border-b px-[23px] py-[18px]">
           <div className="w-[36px]" />

--- a/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
+++ b/src/app/(route)/items/[itemID]/_component/ReviewModal.tsx
@@ -119,7 +119,7 @@ export default function ReviewModal(props: PropsType) {
     const status =
       action === 'create'
         ? await addReview({ itemId, formData })
-        : await editReview({ itemId, reviewId, formData })
+        : await editReview({ reviewId, formData })
 
     if (status === 200) {
       setShowReviewModal(false)

--- a/src/app/(route)/items/[itemID]/_component/ReviewSection.tsx
+++ b/src/app/(route)/items/[itemID]/_component/ReviewSection.tsx
@@ -14,12 +14,18 @@ import { ReviewItemSkeleton } from './ReviewSkeletonUI'
 
 import { sortOptions } from '../_constants'
 
-export default function ReviewSection({ itemInfo }: ItemInfo) {
+interface PropsType {
+  accessToken: string
+  itemInfo: ItemInfo
+}
+
+export default function ReviewSection(props: PropsType) {
+  const { accessToken, itemInfo } = props
   const [showReviewModal, setShowReviewModal] = useState(false)
   const [sortOption, setSortOption] = useState<SortOption>('NEWEST')
 
   const { data, reviewList, fetchNextPage, isFetchingNextPage, hasNextPage } =
-    useSearchItemQuery(itemInfo.id, sortOption)
+    useSearchItemQuery(itemInfo.id, sortOption, accessToken)
 
   /** 추가 데이터 요청(리뷰 더보기) */
   const handleLoadMore = () => {

--- a/src/app/(route)/items/[itemID]/page.tsx
+++ b/src/app/(route)/items/[itemID]/page.tsx
@@ -2,14 +2,23 @@ import React, { Suspense } from 'react'
 import Image from 'next/image'
 
 import { fetchItemDetail } from '@/app/_hook/api/useItemDetail'
+import { getCookie } from '@/app/_utils/cookie'
 import { categoryFormatter } from '../../../_utils/categoryFormatter'
 
 import ActionButtons from './_component/ActionButtons'
 import { ReviewSectionSkeletonUI } from './_component/ReviewSkeletonUI'
 import ReviewSection from './_component/ReviewSection'
 
-export default async function DetailPage() {
-  const itemData = await fetchItemDetail(202)
+type Props = {
+  params: { itemId: number }
+}
+
+export default async function DetailPage({ params }: Props) {
+  const { itemId } = params
+
+  const itemData = await fetchItemDetail(itemId)
+
+  const accessToken = getCookie('accessToken')
 
   const { itemInfo, hobbyName, itemUrl, itemAvgRate, favoriteCount } = itemData
 
@@ -68,9 +77,9 @@ export default async function DetailPage() {
           <ActionButtons itemUrl={itemUrl} itemId={itemInfo.id} />
         </div>
       </article>
-      {/* <Suspense fallback={<ReviewSectionSkeletonUI />}> */}
-      <ReviewSection itemInfo={itemInfo} />
-      {/* </Suspense> */}6fa3156f3be9be758460d86a471a0
+      <Suspense fallback={<ReviewSectionSkeletonUI />}>
+        <ReviewSection itemInfo={itemInfo} accessToken={accessToken} />
+      </Suspense>
     </section>
   )
 }

--- a/src/app/_components/modal/index.tsx
+++ b/src/app/_components/modal/index.tsx
@@ -20,8 +20,8 @@ function Modal({ isScrollActive = false, children }: ModalProps) {
         className={cn(
           'absolute left-[50%] top-[50%] max-h-[90vh] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-[8px] bg-white',
           {
-            'overflow-scroll': isScrollActive,
-            'overflow-hidden': !isScrollActive,
+            'overflow-y-scroll': isScrollActive,
+            'overflow-x-hidden': !isScrollActive,
           },
         )}
       >

--- a/src/app/_hook/api/useAddItem.ts
+++ b/src/app/_hook/api/useAddItem.ts
@@ -1,9 +1,10 @@
 import { useMutation } from '@tanstack/react-query'
 
 import { ItemState } from '@/app/_types/addItem.type'
+import { getCookie } from '@/app/_utils/cookie'
 
 async function postAddItem(params: ItemState) {
-  const accessToken = localStorage.getItem('accessToken')
+  const accessToken = await getCookie('accessToken')
 
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/enroll`,

--- a/src/app/_hook/api/useAddReview.ts
+++ b/src/app/_hook/api/useAddReview.ts
@@ -10,16 +10,13 @@ interface AddReviewRequest {
 async function postAddReview({ itemId, formData }: AddReviewRequest) {
   const accessToken = await getCookie('accessToken')
 
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/${itemId}/reviews`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: formData,
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/reviews`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
     },
-  )
+    body: formData,
+  })
 
   const data = await res.json()
 

--- a/src/app/_hook/api/useDeleteReview.ts
+++ b/src/app/_hook/api/useDeleteReview.ts
@@ -2,16 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { getCookie } from '@/app/_utils/cookie'
 
-interface DeleteReviewRequest {
-  itemId: number
-  reviewId: number
-}
-
-async function postAddReview({ itemId, reviewId }: DeleteReviewRequest) {
+async function deleteReview(reviewId: number) {
   const accessToken = await getCookie('accessToken')
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/${itemId}/reviews/${reviewId}`,
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/reviews/${reviewId}`,
     {
       method: 'DELETE',
       headers: {
@@ -30,8 +25,8 @@ async function postAddReview({ itemId, reviewId }: DeleteReviewRequest) {
 export default function useDeleteReview() {
   const queryClient = useQueryClient()
 
-  return useMutation<void, Error, DeleteReviewRequest>({
-    mutationFn: ({ itemId, reviewId }) => postAddReview({ itemId, reviewId }),
+  return useMutation<void, Error, number>({
+    mutationFn: (reviewId) => deleteReview(reviewId),
     onSuccess: () => {
       alert('리뷰 삭제 성공!')
 

--- a/src/app/_hook/api/useEditReview.ts
+++ b/src/app/_hook/api/useEditReview.ts
@@ -21,9 +21,9 @@ async function postReviewData({ reviewId, formData }: EditReviewRequest) {
     },
   )
 
-  const data = await res.json()
-
   if (!res.ok) {
+    const data = await res.json()
+
     throw data.message
   }
 

--- a/src/app/_hook/api/useEditReview.ts
+++ b/src/app/_hook/api/useEditReview.ts
@@ -3,20 +3,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCookie } from '@/app/_utils/cookie'
 
 interface EditReviewRequest {
-  itemId: number
   reviewId: number
   formData: FormData
 }
 
-async function postReviewData({
-  itemId,
-  reviewId,
-  formData,
-}: EditReviewRequest) {
+async function postReviewData({ reviewId, formData }: EditReviewRequest) {
   const accessToken = await getCookie('accessToken')
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/${itemId}/reviews/${reviewId}`,
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/reviews/${reviewId}`,
     {
       method: 'PUT',
       headers: {
@@ -39,8 +34,8 @@ export default function useEditReview() {
   const queryClient = useQueryClient()
 
   return useMutation<number, Error, EditReviewRequest>({
-    mutationFn: ({ itemId, reviewId, formData }) =>
-      postReviewData({ itemId, reviewId, formData }),
+    mutationFn: ({ reviewId, formData }) =>
+      postReviewData({ reviewId, formData }),
     onSuccess: () => {
       alert('리뷰 수정 성공!')
 

--- a/src/app/_hook/api/useReviewLikeAction.ts
+++ b/src/app/_hook/api/useReviewLikeAction.ts
@@ -3,20 +3,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCookie } from '@/app/_utils/cookie'
 
 interface ReviewLikeRequest {
-  itemId: number
   reviewId: number
   isLiked: boolean
 }
 
-async function postReviewLikeAction({
-  itemId,
-  reviewId,
-  isLiked,
-}: ReviewLikeRequest) {
+async function postReviewLikeAction({ reviewId, isLiked }: ReviewLikeRequest) {
   const accessToken = await getCookie('accessToken')
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/${itemId}/reviews/${reviewId}/like`,
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/reviews/${reviewId}/like`,
     {
       method: isLiked ? 'DELETE' : 'POST',
       headers: {
@@ -36,8 +31,8 @@ export default function useReviewLikeAction() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, ReviewLikeRequest>({
-    mutationFn: ({ itemId, reviewId, isLiked }) =>
-      postReviewLikeAction({ itemId, reviewId, isLiked }),
+    mutationFn: ({ reviewId, isLiked }) =>
+      postReviewLikeAction({ reviewId, isLiked }),
     onSuccess: () => {
       alert('성공!')
 

--- a/src/app/_hook/api/useSaveToWishlist.ts
+++ b/src/app/_hook/api/useSaveToWishlist.ts
@@ -8,7 +8,7 @@ export async function postSaveToWishlist(itemIds: number[]) {
   const accessToken = await getCookie('accessToken')
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/items/myitems
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/favorites/items
         `,
     {
       method: 'POST',

--- a/src/app/_types/review.type.ts
+++ b/src/app/_types/review.type.ts
@@ -1,10 +1,8 @@
 export interface ItemInfo {
-  itemInfo: {
-    id: number
-    name: string
-    price: number
-    image: string
-  }
+  id: number
+  name: string
+  price: number
+  image: string
 }
 
 export interface MemberInfo {


### PR DESCRIPTION
## 1. Changes

- 아이템, 아이템 상세 페이지 연동 ➡️ 클릭 시 해당 상품 상세 페이지로 이동
- 리뷰 목록 API 매개변수로 쿠키 전달 ➡️ Streaming, Suspense 정상 동작
- 아이템 등록 토큰 값 호출 로직 변경 ➡️ (localStorage 👉 cookie)
- 아이템 찜, 리뷰(목록 조회, 등록, 좋아요, 수정, 삭제) API 일괄 URL 변경 및 itemId 매개변수 삭제

<모달>
- 기존에 모달에서 스크롤이 x축에도 생성되었는데, 추후에 x축 스크롤을 사용할 일이 없을 것 같다고 판단해 관련 코드 수정했습니다!
```
 {
     'overflow-y-scroll': isScrollActive,
     'overflow-x-hidden': !isScrollActive,
 },
```

- 리뷰 모달의 경우 스크롤을 추가했습니다!

<br/>

## 2. Screenshot

## 3. Issues
- 🚨 리뷰 수정 시 에러 발생
- 🚨 리뷰 좋아요 취소 시 에러 발생

## 4. To Reviewer

@yeeeerim 
일단 급한 대로 먼저 병합하고 추후에 수정사항이 반영되면 또 pr을 올리는 것도 좋을 것 같습니다.
아이템 찜, 리뷰(목록 조회, 등록, 좋아요, 삭제)는 테스트 완료했습니다!

## 5. Plans
