### PR TITLE
feat: toast UI 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "^3.1.1",
     "react": "^18",
     "react-dom": "^18",
+    "react-hot-toast": "^2.4.1",
     "react-intersection-observer": "^9.8.0",
     "tailwind-merge": "^2.2.1"
   },

--- a/src/app/_components/layout/Layout.tsx
+++ b/src/app/_components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react'
+import { Toaster } from 'react-hot-toast'
 import Header from './Header'
 
 function Layout({ children }: { children: ReactNode }) {
@@ -6,6 +7,7 @@ function Layout({ children }: { children: ReactNode }) {
     <div className="my-0 flex h-screen flex-col">
       <Header />
       <div className="h-full pb-[18px]">{children}</div>
+      <Toaster />
     </div>
   )
 }

--- a/src/app/_utils/toast.ts
+++ b/src/app/_utils/toast.ts
@@ -1,0 +1,26 @@
+import { toast } from 'react-hot-toast'
+
+interface IToast {
+  type: 'success' | 'error'
+  message: string
+  duration?: number
+}
+
+const renderToast = ({ type, message, duration = 3500 }: IToast) => {
+  switch (type) {
+    case 'error':
+      return toast.error(message, {
+        duration,
+      })
+    case 'success':
+      return toast.success(message, {
+        duration,
+      })
+    default:
+      return toast(message, {
+        duration,
+      })
+  }
+}
+
+export default renderToast

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,6 +1406,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.10:
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
+  integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -2215,6 +2220,13 @@ react-dom@^18:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-intersection-observer@^9.8.0:
   version "9.8.0"


### PR DESCRIPTION
## 1. Changes

- #25 
- react-hot-toast 라이브러리 추가
현재 기본적으로 제공되는 success, error만 반영해 두었습니다!

<br/>

### 사용

### - type
`success` or `error`

### - duration
toast 지속 시간 (기본 3.5초로 설정)


```tsx
import renderToast from '../_utils/toast'

<button
     type="button"
     onClick={() =>
        renderToast({
           type: 'error',
           message: '회원가입 실패',
         })
       }
>
   버튼
</button>
```

<br/>

## 2. Screenshot

![화면-기록-2024-02-27-오후-6 35 21](https://github.com/uju-in/lime-frontend/assets/114549939/aa926061-f3f9-420b-b064-15a02d6e959f)


## 3. Issues

## 4. To Reviewer

@yeeeerim 
추후에 커스텀 디자인이 추가되면 다시 PR 올리겠습니다!
+) yarn install 필요합니다~!

<br/>

## 5. Plans
