### PR TITLE
design: 검색 결과 페이지 반응형 구현

### DIFF
--- a/src/app/(route)/(withLayout)/items/_components/SortBox.tsx
+++ b/src/app/(route)/(withLayout)/items/_components/SortBox.tsx
@@ -52,8 +52,8 @@ export default function SortBox(props: Props) {
             return (
               <li
                 className={cn('cursor-pointer hover:text-black', {
-                  'font-semibold text-black': sortOption === item,
-                  'font-normal text-[#868585]': sortOption !== item,
+                  'font-semibold text-black': sortOption.value === item.value,
+                  'font-normal text-[#868585]': sortOption.value !== item.value,
                 })}
                 key={item.value}
                 onClick={() => {

--- a/src/app/(route)/(withLayout)/items/_components/SortBox.tsx
+++ b/src/app/(route)/(withLayout)/items/_components/SortBox.tsx
@@ -47,7 +47,7 @@ export default function SortBox(props: Props) {
         />
       </button>
       {showSortList && (
-        <ul className="absolute right-0 top-[25px] flex flex-col gap-[5px] rounded-[4px] border border-[#ededed] bg-white p-[10px_15px] shadow-[0px_0px_5.85px_2.25px_rgba(0,0,0,0.10)]">
+        <ul className="absolute right-0 top-[25px] z-50 flex flex-col gap-[5px] rounded-[4px] border border-[#ededed] bg-white p-[10px_15px] shadow-[0px_0px_5.85px_2.25px_rgba(0,0,0,0.10)]">
           {SortOption.map((item) => {
             return (
               <li

--- a/src/app/(route)/(withLayout)/items/layout.tsx
+++ b/src/app/(route)/(withLayout)/items/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ReactNode } from 'react'
 import RQProvider from '@/app/_components/RQProvider'
 import MoNavbar from '@/app/_components/layout/mobile/MoNavbar'

--- a/src/app/(route)/(withLayout)/items/page.tsx
+++ b/src/app/(route)/(withLayout)/items/page.tsx
@@ -14,7 +14,7 @@ export default function page() {
       </div>
       <div
         className={cn(
-          'mx-auto flex w-[1024px] max-w-full justify-center gap-[50px] px-[10px]',
+          'mx-auto flex w-[1200px] max-w-full justify-center gap-[50px] px-[10px]',
           'mo:px-[16px]',
         )}
       >

--- a/src/app/(route)/(withLayout)/saves/_component/SaveComponent.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/SaveComponent.tsx
@@ -65,7 +65,7 @@ export default function SaveComponent() {
   }
 
   return (
-    <section className="mx-auto h-full max-w-[1200px]">
+    <section className="mx-auto h-full max-w-[1200px] px-[10px]">
       {/* Header */}
       {mode === SavePageMode.DEFAULT && (
         <SaveHeader.Default

--- a/src/app/(route)/(withLayout)/search/_components/MoSearchHeader.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/MoSearchHeader.tsx
@@ -1,10 +1,18 @@
+'use client'
+
 import React from 'react'
 import { cn } from '@/app/_utils/twMerge'
+import { MoHeader } from '@/app/_components/layout/mobile/MoHeader'
+import { useSearchParams } from 'next/navigation'
 
 export default function MoSearchHeader() {
+  const searchParams = useSearchParams()
+  const keyword = searchParams.get('keyword') || ''
+
   return (
     <div className={cn('hidden', 'mo:block')}>
-      <h1 className="block text-[24px] font-bold">아이템</h1>
+      <MoHeader.Back title={`'${keyword}' 검색 결과`} />
+      <h1 className="mt-[51px] block text-[21px] font-bold">아이템</h1>
     </div>
   )
 }

--- a/src/app/(route)/(withLayout)/search/_components/MoSearchHeader.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/MoSearchHeader.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { cn } from '@/app/_utils/twMerge'
+
+export default function MoSearchHeader() {
+  return (
+    <div className={cn('hidden', 'mo:block')}>
+      <h1 className="block text-[24px] font-bold">아이템</h1>
+    </div>
+  )
+}

--- a/src/app/(route)/(withLayout)/search/_components/SearchItem.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SearchItem.tsx
@@ -12,7 +12,7 @@ export function SearchItem({ item }: { item: ItemType }) {
   }
 
   return (
-    <div className="flex w-[184px] flex-col gap-[7px] text-[14px]">
+    <div className="flex flex-col gap-[7px] text-[14px]">
       <Image
         onClick={handleItemClick}
         className="cursor-pointer rounded-[8px]"

--- a/src/app/(route)/(withLayout)/search/_components/SearchItem.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SearchItem.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import { ItemType } from '@/app/_types/item.type'
+
+export function SearchItem({ item }: { item: ItemType }) {
+  const { name, price, id, image, createdAt, favoriteCount, reviewCount } =
+    item.itemSummary
+  const router = useRouter()
+
+  const handleItemClick = () => {
+    router.push(`/items/${id}`)
+  }
+
+  return (
+    <div className="flex w-[184px] flex-col gap-[7px] text-[14px]">
+      <Image
+        onClick={handleItemClick}
+        className="cursor-pointer rounded-[8px]"
+        src={image}
+        alt="item-image"
+        width={184}
+        height={184}
+      />
+      <div
+        onClick={handleItemClick}
+        className="line-clamp-2 h-[42px] cursor-pointer text-[#515151] hover:underline"
+      >
+        {name}
+      </div>
+      <strong>{price.toLocaleString()}원</strong>
+      <div className="flex gap-[20px] text-[13px] text-[#6F6F6F]">
+        <div className="flex cursor-pointer">
+          <Image
+            src="/image/icon/icon-save.svg"
+            alt="save"
+            width={18}
+            height={18}
+          />
+          <div>{favoriteCount}</div>
+        </div>
+        <div className="flex cursor-pointer">
+          <Image
+            src="/image/icon/icon-review.svg"
+            alt="review"
+            width={18}
+            height={18}
+          />
+          <div>{reviewCount}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { ItemType } from '@/app/_types/item.type'
 import useItemListData from '@/app/_hook/api/items/useItemListData'
@@ -10,56 +9,7 @@ import { cn } from '@/app/_utils/twMerge'
 import { useInView } from 'react-intersection-observer'
 import { SortOption } from '../_constants'
 import SortBox from './SortBox'
-
-export function Item({ item }: { item: ItemType }) {
-  const { name, price, id, image, createdAt, favoriteCount, reviewCount } =
-    item.itemSummary
-  const router = useRouter()
-
-  const handleItemClick = () => {
-    router.push(`/items/${id}`)
-  }
-
-  return (
-    <div className="flex w-[184px] flex-col gap-[7px] text-[14px]">
-      <Image
-        onClick={handleItemClick}
-        className="cursor-pointer rounded-[8px]"
-        src={image}
-        alt="item-image"
-        width={184}
-        height={184}
-      />
-      <div
-        onClick={handleItemClick}
-        className="line-clamp-2 h-[42px] cursor-pointer text-[#515151] hover:underline"
-      >
-        {name}
-      </div>
-      <strong>{price.toLocaleString()}원</strong>
-      <div className="flex gap-[20px] text-[13px] text-[#6F6F6F]">
-        <div className="flex cursor-pointer">
-          <Image
-            src="/image/icon/icon-save.svg"
-            alt="save"
-            width={18}
-            height={18}
-          />
-          <div>{favoriteCount}</div>
-        </div>
-        <div className="flex cursor-pointer">
-          <Image
-            src="/image/icon/icon-review.svg"
-            alt="review"
-            width={18}
-            height={18}
-          />
-          <div>{reviewCount}</div>
-        </div>
-      </div>
-    </div>
-  )
-}
+import { SearchItem } from './SearchItem'
 
 export default function SearchItemList({ keyword }: { keyword: string }) {
   const [sortOption, setSortOption] = useState(SortOption[2])
@@ -115,7 +65,7 @@ export default function SearchItemList({ keyword }: { keyword: string }) {
       </div>
       <div className="grid grid-cols-[repeat(auto-fill,184px)] gap-x-[19px] gap-y-[25px]">
         {itemList.map((item: ItemType) => {
-          return <Item item={item} key={item.cursorId} />
+          return <SearchItem item={item} key={item.cursorId} />
         })}
       </div>
       {isFetchingNextPage ? <div>Loading..</div> : <div ref={ref} />}

--- a/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
@@ -63,7 +63,13 @@ export default function SearchItemList({ keyword }: { keyword: string }) {
         </p>
         <SortBox sortOption={sortOption} setSortOption={setSortOption} />
       </div>
-      <div className="grid grid-cols-[repeat(auto-fill,184px)] gap-x-[19px] gap-y-[25px]">
+      <div
+        className={cn(
+          'grid grid-cols-6 gap-x-[19px] gap-y-[25px]',
+          'tablet:grid-cols-5',
+          'mo:grid-cols-3',
+        )}
+      >
         {itemList.map((item: ItemType) => {
           return <SearchItem item={item} key={item.cursorId} />
         })}

--- a/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SearchItemList.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { ItemType } from '@/app/_types/item.type'
 import useItemListData from '@/app/_hook/api/items/useItemListData'
+import { cn } from '@/app/_utils/twMerge'
 import { useInView } from 'react-intersection-observer'
 import { SortOption } from '../_constants'
 import SortBox from './SortBox'
@@ -101,7 +102,12 @@ export default function SearchItemList({ keyword }: { keyword: string }) {
 
   return (
     <>
-      <div className="relative my-[30px] flex items-center justify-between">
+      <div
+        className={cn(
+          'relative my-[30px] flex items-center justify-between',
+          'mo:mb-[12px] mo:mt-[16px]',
+        )}
+      >
         <p className="text-[14px] font-medium">
           총 {itemList.length}개의 아이템
         </p>

--- a/src/app/(route)/(withLayout)/search/_components/SortBox.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SortBox.tsx
@@ -52,8 +52,8 @@ export default function SortBox(props: Props) {
             return (
               <li
                 className={cn('cursor-pointer hover:text-black', {
-                  'font-semibold text-black': sortOption === item,
-                  'font-normal text-[#868585]': sortOption !== item,
+                  'font-semibold text-black': sortOption.value === item.value,
+                  'font-normal text-[#868585]': sortOption.value !== item.value,
                 })}
                 key={item.value}
                 onClick={() => {

--- a/src/app/(route)/(withLayout)/search/_components/SortBox.tsx
+++ b/src/app/(route)/(withLayout)/search/_components/SortBox.tsx
@@ -47,7 +47,7 @@ export default function SortBox(props: Props) {
         />
       </button>
       {showSortList && (
-        <ul className="absolute right-0 top-[25px] flex flex-col gap-[5px] rounded-[4px] border border-[#ededed] bg-white p-[10px_15px] shadow-[0px_0px_5.85px_2.25px_rgba(0,0,0,0.10)]">
+        <ul className="absolute right-0 top-[25px] z-50 flex flex-col gap-[5px] rounded-[4px] border border-[#ededed] bg-white p-[10px_15px] shadow-[0px_0px_5.85px_2.25px_rgba(0,0,0,0.10)]">
           {SortOption.map((item) => {
             return (
               <li

--- a/src/app/(route)/(withLayout)/search/layout.tsx
+++ b/src/app/(route)/(withLayout)/search/layout.tsx
@@ -1,5 +1,6 @@
-import RQProvider from '@/app/_components/RQProvider'
 import React, { ReactNode } from 'react'
+import RQProvider from '@/app/_components/RQProvider'
+import MoNavbar from '@/app/_components/layout/mobile/MoNavbar'
 import MoSearchHeader from './_components/MoSearchHeader'
 
 export default function SearchLayout({ children }: { children: ReactNode }) {
@@ -9,6 +10,7 @@ export default function SearchLayout({ children }: { children: ReactNode }) {
         <MoSearchHeader />
         {children}
       </div>
+      <MoNavbar />
     </RQProvider>
   )
 }

--- a/src/app/(route)/(withLayout)/search/layout.tsx
+++ b/src/app/(route)/(withLayout)/search/layout.tsx
@@ -1,0 +1,14 @@
+import RQProvider from '@/app/_components/RQProvider'
+import React, { ReactNode } from 'react'
+import MoSearchHeader from './_components/MoSearchHeader'
+
+export default function SearchLayout({ children }: { children: ReactNode }) {
+  return (
+    <RQProvider>
+      <div className="mx-auto w-[1200px] max-w-full p-[10px]">
+        <MoSearchHeader />
+        {children}
+      </div>
+    </RQProvider>
+  )
+}

--- a/src/app/(route)/(withLayout)/search/page.tsx
+++ b/src/app/(route)/(withLayout)/search/page.tsx
@@ -1,4 +1,4 @@
-import RQProvider from '@/app/_components/RQProvider'
+import { cn } from '@/app/_utils/twMerge'
 import React from 'react'
 import SearchItemList from './_components/SearchItemList'
 
@@ -10,11 +10,11 @@ export default function page({ searchParams }: Props) {
   const { keyword } = searchParams
 
   return (
-    <div className="mx-auto w-[1200px]">
-      <h1 className="text-[24px] font-bold">{`'${keyword}' 검색 결과`}</h1>
-      <RQProvider>
-        <SearchItemList keyword={keyword} />
-      </RQProvider>
-    </div>
+    <>
+      <h1
+        className={cn('block text-[24px] font-bold', 'mo:hidden')}
+      >{`'${keyword}' 검색 결과`}</h1>
+      <SearchItemList keyword={keyword} />
+    </>
   )
 }

--- a/src/app/_components/layout/Footer.tsx
+++ b/src/app/_components/layout/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <footer
       className={cn(
-        'm-[49px_auto_140px] flex w-[1024px] max-w-full bg-white px-[10px]',
+        'm-[49px_auto_140px] flex w-[1200px] max-w-full bg-white px-[10px]',
         'mo:hidden',
       )}
     >

--- a/src/app/_components/layout/Header.tsx
+++ b/src/app/_components/layout/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
 
   if (isSearchView)
     return (
-      <div className="mx-auto my-[23px] flex w-[1024px] max-w-full items-center justify-between px-[10px]">
+      <div className="mx-auto my-[23px] flex w-[1200px] max-w-full items-center justify-between px-[10px]">
         <div className="relative mx-auto h-[52.5px] w-fit" ref={searchRef}>
           <Search />
         </div>
@@ -32,7 +32,7 @@ export default function Header() {
   return (
     <div
       className={cn(
-        'mx-auto my-[23px] flex w-[1024px] max-w-full items-center justify-between px-[10px]',
+        'mx-auto my-[23px] flex w-[1200px] max-w-full items-center justify-between px-[10px]',
         'mo:hidden',
       )}
     >

--- a/src/app/_components/layout/mobile/MoHeader.tsx
+++ b/src/app/_components/layout/mobile/MoHeader.tsx
@@ -44,7 +44,7 @@ export namespace MoHeader {
     return (
       <header
         className={cn(
-          'hidden items-center justify-between py-[10px]',
+          'fixed left-0 right-0 top-0 hidden items-center justify-between bg-white py-[10px]',
           'mo:flex',
           {
             'mo:hidden': scrollDirection === 'down',


### PR DESCRIPTION
## 1. Changes

- 검색 결과 페이지 반응형 구현
- 레이아웃 수정 - `width: 1024px -> 1200px`
- MoHeader.Back 스크롤 문제 해결

## 2. Screenshot

<img src="https://github.com/uju-in/lime-frontend/assets/58348662/27274024-3c33-495d-a308-68abe5cf4b78" alt="image" width="300">

![Mar-23-2024 20-18-54](https://github.com/uju-in/lime-frontend/assets/58348662/1d08a834-0a04-4ae2-b58c-00355b3bdc2f)


## 3. Issues

1. Back 컴포넌트만 스크롤 시 숨겨지는 기능이 동작하지 않아서 css 추가했는데 맞는지 확인 부탁드립니다 !
- [fix: MoHeader.Back 스크롤 적용 안 되는 문제 해결](e783d82d1ed99d254be631c9d97a3d3e4d9a96f3)

<br>

2. Figma 상으로 보면 아래와 같은 UI가 있는데,
<img width="415" alt="image" src="https://github.com/uju-in/lime-frontend/assets/58348662/cd48f67f-51bf-4af2-9414-a48543c81aea">

검색 결과 페이지에 투표를 나중에 넣기로 해서 이 부분도 제외하고 구현하였습니다.

<br>

3. Figma 에서 Header가 아래처럼 되어있는데,
<img width="421" alt="image" src="https://github.com/uju-in/lime-frontend/assets/58348662/8cf8bd7b-c06d-41c0-aa64-42086aeac7f2">

임의로 `MoHeader.Back` UI로 변경해서 구현했습니다,,,

> => 이유 : 모바일 용 검색 UI를 별도의 페이지로 구분하여 생성하였는데(`/mo-search`), Figma 처럼 구현할 경우 input을 클릭하면 `/mo-search` 로 이동하도록 구현해야 함
> 1. 사용자 입장에서 input UI처럼 생겼는데 button처럼 동작하여 페이지가 이동되는 것이 맞지 않다고 생각
> 2. 페이지 히스토리에도 문제가 발생할 것으로 예상
> 3. `/mo-search`로 이동할 때 직전에 입력한 keyword를 가지고 이동시켜야 되는데, 이러한 로직이 또 추가되어야 함


## 4. To Reviewer

- @mintmin0320 
- 이슈 위주로만 확인해주시면 감사하겠습니다! 특이사항은 없었습니다~

## 5. Plans

- [ ] - 찜 목록 반응형