### PR TITLE
feat: next client cookies 라이브러리 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-config-prettier": "^9.1.0",
     "next": "14.0.4",
+    "next-client-cookies": "^1.1.0",
     "prettier": "^3.1.1",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(route)/(withLayout)/layout.tsx
+++ b/src/app/(route)/(withLayout)/layout.tsx
@@ -1,13 +1,16 @@
 import Footer from '@/app/_components/layout/Footer'
 import Header from '@/app/_components/layout/Header'
+import { CookiesProvider } from 'next-client-cookies/server'
 import React, { ReactNode } from 'react'
 
 export default function WithLayout({ children }: { children: ReactNode }) {
   return (
     <main className="my-0 flex flex-col">
-      <Header />
-      <div className="mb-[18px]">{children}</div>
-      <Footer />
+      <CookiesProvider>
+        <Header />
+        <div className="mb-[18px]">{children}</div>
+        <Footer />
+      </CookiesProvider>
     </main>
   )
 }

--- a/src/app/_hook/api/reviews/useReviewListData.ts
+++ b/src/app/_hook/api/reviews/useReviewListData.ts
@@ -1,24 +1,24 @@
 import { useMemo } from 'react'
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
 import { PagesResponse, SortOption } from '@/app/_types/review.type'
-import { getCookie } from 'cookies-next'
+import { useCookies } from 'next-client-cookies'
 import { reviewKeys } from '.'
 
 interface ReviewQueryParams {
   pageParam: string | null
   itemId: number
   sortOption: SortOption
+  accessToken: string
 }
 
 async function fetchReviewList({
   pageParam,
   itemId,
   sortOption,
+  accessToken,
 }: ReviewQueryParams) {
   /** 기본 3개 - 추가 10개 */
   const REVIEW_DATA_SIZE = !pageParam ? 3 : 10
-
-  const accessToken = getCookie('accessToken')
 
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/reviews?itemId=${itemId}&size=${REVIEW_DATA_SIZE}&cursorId=${pageParam}&reviewSortCondition=${sortOption}`,
@@ -42,11 +42,14 @@ async function fetchReviewList({
 }
 
 export const useSearchItemQuery = (itemId: number, sortOption: SortOption) => {
+  const cookies = useCookies()
+  const accessToken = cookies.get('accessToken') ?? ''
+
   const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
     useSuspenseInfiniteQuery({
       queryKey: reviewKeys.reviewList(itemId, sortOption).queryKey,
       queryFn: ({ pageParam = null }) =>
-        fetchReviewList({ pageParam, itemId, sortOption }),
+        fetchReviewList({ pageParam, itemId, sortOption, accessToken }),
       initialPageParam: null,
       getNextPageParam: (lastPage: PagesResponse) => {
         return lastPage.nextCursorId

--- a/src/app/_hook/api/saves/useSavesList.ts
+++ b/src/app/_hook/api/saves/useSavesList.ts
@@ -1,15 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
-import { getCookie } from 'cookies-next'
+import { useCookies } from 'next-client-cookies'
 import { saveKeys } from '.'
 
 interface SaveListRequest {
   type: 'all' | 'folder' | 'item'
   folderId?: number
+  accessToken: string
 }
 
-async function getSavesList({ type, folderId }: SaveListRequest) {
-  const accessToken = getCookie('accessToken')
-
+async function getSavesList({ type, folderId, accessToken }: SaveListRequest) {
   let url = `${process.env.NEXT_PUBLIC_BASE_URL}/api/favorites`
 
   if (type === 'folder') {
@@ -35,9 +34,12 @@ export default function useSaveList(
   type: 'all' | 'folder' | 'item',
   folderId?: number,
 ) {
+  const cookies = useCookies()
+  const accessToken = cookies.get('accessToken') ?? ''
+
   const { data, isLoading, isError } = useQuery({
     queryKey: saveKeys.saveList(folderId || 0, type).queryKey,
-    queryFn: () => getSavesList({ type, folderId }),
+    queryFn: () => getSavesList({ type, folderId, accessToken }),
   })
 
   return {

--- a/src/app/_hook/api/votes/useFavoritesList.ts
+++ b/src/app/_hook/api/votes/useFavoritesList.ts
@@ -1,15 +1,18 @@
 import { useQuery } from '@tanstack/react-query'
-import { getCookie } from 'cookies-next'
+import { useCookies } from 'next-client-cookies'
 import { voteKeys } from '.'
 
 interface RequestInfo {
   type: 'folder' | 'item'
   folderId?: number | null
+  accessToken: string
 }
 
-export async function fetchFavoriteList({ type, folderId }: RequestInfo) {
-  const accessToken = getCookie('accessToken')
-
+export async function fetchFavoriteList({
+  type,
+  folderId,
+  accessToken,
+}: RequestInfo) {
   let url = `${process.env.NEXT_PUBLIC_BASE_URL}/api/favorites?favoriteTypeCondition=${type}`
 
   if (type === 'item' && folderId) {
@@ -37,13 +40,16 @@ export const useFavoritesList = (
   type: 'folder' | 'item',
   folderId?: number | null,
 ) => {
+  const cookies = useCookies()
+  const accessToken = cookies.get('accessToken') ?? ''
+
   const {
     data: itemList,
     isError,
     isSuccess,
   } = useQuery({
     queryKey: voteKeys.favorites(folderId as number).queryKey,
-    queryFn: () => fetchFavoriteList({ type, folderId }),
+    queryFn: () => fetchFavoriteList({ type, folderId, accessToken }),
     staleTime: 1000 * 60,
   })
 

--- a/src/app/_hook/api/votes/useVoteDetail.ts
+++ b/src/app/_hook/api/votes/useVoteDetail.ts
@@ -1,11 +1,12 @@
 import { VoteDetailType } from '@/app/_types/detailVote.type'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { getCookie } from 'cookies-next'
+import { useCookies } from 'next-client-cookies'
 import { voteKeys } from '.'
 
-async function fetchVoteDetail(voteId: number): Promise<VoteDetailType> {
-  const accessToken = getCookie('accessToken')
-
+async function fetchVoteDetail(
+  voteId: number,
+  accessToken: string,
+): Promise<VoteDetailType> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/votes/${voteId}`,
     {
@@ -21,20 +22,23 @@ async function fetchVoteDetail(voteId: number): Promise<VoteDetailType> {
   const data = await res.json()
 
   if (!res.ok) {
-    throw data.message
+    throw Error(data.message)
   }
 
   return data
 }
 
 export const useVoteDetail = (voteId: number) => {
+  const cookies = useCookies()
+  const accessToken = cookies.get('accessToken') ?? ''
+
   const {
     data: voteData,
     isError,
     isSuccess,
   } = useSuspenseQuery<VoteDetailType, Error, VoteDetailType>({
     queryKey: voteKeys.detail(voteId).queryKey,
-    queryFn: () => fetchVoteDetail(voteId),
+    queryFn: () => fetchVoteDetail(voteId, accessToken),
     staleTime: 1000 * 60,
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,6 +1749,11 @@ jiti@^1.19.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
   integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1931,6 +1936,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+next-client-cookies@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-client-cookies/-/next-client-cookies-1.1.0.tgz#34c7a3345da0388ea396531bcab3167774a6357a"
+  integrity sha512-e/rqQTXHSFuvUJELMeCDgM7dWW6IUNOGr7noWyRSgE/5l033UaqseDrjShfRZYG45JnrYKoX653OdXTJ8cn+NA==
+  dependencies:
+    js-cookie "^3.0.5"
 
 next@14.0.4:
   version "14.0.4"


### PR DESCRIPTION
## 1. Changes

- next client cookies 라이브러리 적용

## 2. Screenshot

#### ❌ before

![](https://velog.velcdn.com/images/mintmin0320/post/4bb84f53-1206-44d9-a67e-e4b461d0cf6d/image.gif)

#### ⭕️ after

![](https://velog.velcdn.com/images/mintmin0320/post/c9b6d1c5-29b6-4bde-8dda-0a32f9bd02e8/image.gif)

## 3. Issues

새로운 라이브러리 추가로 `yarn install` 필요합니다!

1. withLayout 폴더 최상위 레이아웃에 Header 컴포넌트를 포함해 Provider로 감싸주었습니다.
추후에 Header에서 토큰을 사용할 소요가 발생하는 것을 고려해서 배치했습니다!

<br/>

2. `useCookies ` 훅을 사용해야 되는데, fetch 함수에서 사용할 수 없는 관계로 react-query hook에서 인자로 토큰 값을 넘겨주는 형태가 되었습니다. 더 좋은 의견 있으시면 피드백 부탁드립니다!

- [관련 작업](https://github.com/uju-in/lime-frontend/commit/9752d7854873caee8a712ecfc48d7c6105d80c87)

### Reference

- [how-i-solve-next.js-v13-cookies-for-server-side-rendering-ssr](https://moshe.io/posts/2023-10-02/how-i-solve-next.js-v13-cookies-for-server-side-rendering-ssr)

- [next-client-cookies](https://github.com/moshest/next-client-cookies)

<br/>

## 4. To Reviewer

@yeeeerim
라이브러리 사용자도 적고 이번 이슈에 대한 레퍼런스가 많지 않아서 적용에 대한 고민을 많이 해봤지만,
정상적으로 잘 동작되는 관계로 사용하는 방향으로 진행하면 좋을 것 같습니다!
이슈와 레퍼런스 위주로 확인해 주시면 될 것 같습니다 🙂

<br/>

## 5. Plans