### PR TITLE
fix: 찜 목록 QA 수정

### DIFF
--- a/src/app/(route)/(withLayout)/saves/[folderId]/_component/SaveFolderHeader.tsx
+++ b/src/app/(route)/(withLayout)/saves/[folderId]/_component/SaveFolderHeader.tsx
@@ -9,6 +9,7 @@ import { useChangeSaveFolderName } from '@/app/_hook/api/saves/useChangeSaveFold
 import { useSetRecoilState } from 'recoil'
 import { saveModeState } from '@/app/_atoms/saveModeState'
 import renderToast from '@/app/_utils/toast'
+import { validateSaveFolderName } from '../../_utils/validation'
 
 /**
  * 찜 폴더 내부 페이지 Header
@@ -122,13 +123,7 @@ export namespace SaveFolderHeader {
     const setMode = useSetRecoilState(saveModeState)
 
     const handleChangeName = useCallback(async () => {
-      if (newFolderName.length > 20 || newFolderName.length === 0) {
-        renderToast({
-          type: 'error',
-          message: '1-20자로 설정해주세요.',
-        })
-        return
-      }
+      if (!validateSaveFolderName(newFolderName)) return
 
       await changeName({ folderId, folderName: newFolderName })
       router.replace(`/saves/${folderId}?name=${newFolderName}`)

--- a/src/app/(route)/(withLayout)/saves/[folderId]/_component/SaveFolderHeader.tsx
+++ b/src/app/(route)/(withLayout)/saves/[folderId]/_component/SaveFolderHeader.tsx
@@ -8,6 +8,7 @@ import useDeleteSave from '@/app/_hook/api/saves/useDeleteSave'
 import { useChangeSaveFolderName } from '@/app/_hook/api/saves/useChangeSaveFolderName'
 import { useSetRecoilState } from 'recoil'
 import { saveModeState } from '@/app/_atoms/saveModeState'
+import renderToast from '@/app/_utils/toast'
 
 /**
  * 찜 폴더 내부 페이지 Header
@@ -121,6 +122,14 @@ export namespace SaveFolderHeader {
     const setMode = useSetRecoilState(saveModeState)
 
     const handleChangeName = useCallback(async () => {
+      if (newFolderName.length > 20 || newFolderName.length === 0) {
+        renderToast({
+          type: 'error',
+          message: '1-20자로 설정해주세요.',
+        })
+        return
+      }
+
       await changeName({ folderId, folderName: newFolderName })
       router.replace(`/saves/${folderId}?name=${newFolderName}`)
       setMode(SavePageMode.DEFAULT)

--- a/src/app/(route)/(withLayout)/saves/_component/AddFolderModal.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/AddFolderModal.tsx
@@ -1,8 +1,10 @@
 import Modal from '@/app/_components/modal'
 import useAddSaveFolder from '@/app/_hook/api/saves/useAddSaveFolder'
+import renderToast from '@/app/_utils/toast'
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 import React, { useCallback, useState } from 'react'
+import { validateSaveFolderName } from '../_utils/validation'
 
 interface Props {
   setShowAddFolderModal: React.Dispatch<React.SetStateAction<boolean>>
@@ -14,6 +16,8 @@ export default function AddFolderModal({ setShowAddFolderModal }: Props) {
   const { mutateAsync: addFolder } = useAddSaveFolder()
 
   const handleAddFolder = useCallback(async () => {
+    if (!validateSaveFolderName(folderName)) return
+
     await addFolder(folderName)
     setShowAddFolderModal(false)
   }, [folderName, setShowAddFolderModal, addFolder])

--- a/src/app/(route)/(withLayout)/saves/_component/MoChangeFolderNameModal.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/MoChangeFolderNameModal.tsx
@@ -21,8 +21,11 @@ export default function MoChangeFolderNameModal(props: Props) {
   const router = useRouter()
 
   const handleChangeName = useCallback(async () => {
-    if (!newFolderName) {
-      renderToast({ type: 'error', message: '폴더 이름을 입력해주세요.' })
+    if (newFolderName.length > 20 || newFolderName.length === 0) {
+      renderToast({
+        type: 'error',
+        message: '1-20자로 설정해주세요.',
+      })
       return
     }
 

--- a/src/app/(route)/(withLayout)/saves/_component/MoChangeFolderNameModal.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/MoChangeFolderNameModal.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/app/_utils/twMerge'
 import renderToast from '@/app/_utils/toast'
 import { useChangeSaveFolderName } from '@/app/_hook/api/saves/useChangeSaveFolderName'
 import { useParams, useRouter } from 'next/navigation'
+import { validateSaveFolderName } from '../_utils/validation'
 
 interface Props {
   originFolderName: string
@@ -21,13 +22,7 @@ export default function MoChangeFolderNameModal(props: Props) {
   const router = useRouter()
 
   const handleChangeName = useCallback(async () => {
-    if (newFolderName.length > 20 || newFolderName.length === 0) {
-      renderToast({
-        type: 'error',
-        message: '1-20자로 설정해주세요.',
-      })
-      return
-    }
+    if (!validateSaveFolderName(newFolderName)) return
 
     await changeName({ folderId: fId, folderName: newFolderName })
     router.replace(`/saves/${fId}?name=${newFolderName}`)

--- a/src/app/(route)/(withLayout)/saves/_component/MoveFolderModal.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/MoveFolderModal.tsx
@@ -1,5 +1,4 @@
 import { saveModeState } from '@/app/_atoms/saveModeState'
-import Modal from '@/app/_components/modal'
 import useMoveSaveItems, {
   MoveSaveItemsRequest,
 } from '@/app/_hook/api/saves/useMoveSaveItems'
@@ -8,7 +7,7 @@ import { SaveFolderType, SavePageMode } from '@/app/_types/save.type'
 import renderToast from '@/app/_utils/toast'
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useSetRecoilState } from 'recoil'
 
 interface Props {
@@ -26,10 +25,46 @@ export default function MoveFolderModal(props: Props) {
     setShowMoveFolderModal,
     setShowAddFolderModal,
   } = props
+
   const [selectFolderId, setSelectFolderId] = useState<number | null>(null)
   const { saveInfo, isLoading, isError } = useSaveList('folder')
   const { mutateAsync: moveItems } = useMoveSaveItems()
   const setMode = useSetRecoilState(saveModeState)
+
+  const [startY, setStartY] = useState(0)
+  const [moveY, setMoveY] = useState(0)
+  const [endY, setEndY] = useState(0)
+
+  const ref: any = useRef(null)
+
+  const onTouchStart = (e: TouchEvent) => {
+    setStartY(e.touches[0].clientY)
+  }
+
+  const onTouchMove = (e: TouchEvent) => {
+    setMoveY(e.targetTouches[0].clientY)
+  }
+
+  const onTouchEnd = (e: TouchEvent) => {
+    setEndY(e.changedTouches[0].clientY)
+  }
+
+  useEffect(() => {
+    ref.current?.addEventListener('touchstart', onTouchStart)
+    ref.current?.addEventListener('touchmove', onTouchMove)
+    ref.current?.addEventListener('touchend', onTouchEnd)
+    return () => {
+      ref.current?.removeEventListener('touchstart', onTouchStart)
+      ref.current?.removeEventListener('touchmove', onTouchMove)
+      ref.current?.removeEventListener('touchend', onTouchEnd)
+    }
+  }, [onTouchEnd, onTouchMove, onTouchStart, ref])
+
+  useEffect(() => {
+    if (endY - startY > 50) {
+      setShowMoveFolderModal(false)
+    }
+  }, [endY, startY, setShowMoveFolderModal])
 
   const handleMoveItems = useCallback(async () => {
     if (!selectFolderId) return
@@ -63,107 +98,120 @@ export default function MoveFolderModal(props: Props) {
   const folderList = saveInfo.favoriteInfos as SaveFolderType[]
 
   return (
-    <Modal innerClassNames="mo:fixed mo:flex mo:flex-col mo:h-[90%] mo:top-auto mo:max-w-full mo:w-full mo:bottom-0 mo:left-0 mo:translate-x-0 mo:translate-y-0">
+    <div
+      id="ModalContainer"
+      className="fixed bottom-0 left-0 right-0 top-0 z-[500] h-screen min-h-screen w-full bg-[rgba(0,0,0,0.7)]"
+    >
       <div
+        id="ModalInner"
         className={cn(
-          'flex flex-col gap-[25px] p-[26px_46px]',
-          'mo:h-full mo:gap-0 mo:p-0',
+          'absolute left-[50%] top-[50%] max-h-[75vh] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-[8px] bg-white',
+          'mo:fixed mo:bottom-0 mo:left-0 mo:top-auto mo:flex mo:h-[90%] mo:w-full mo:max-w-full mo:translate-x-0 mo:translate-y-0 mo:flex-col',
         )}
+        style={{ height: `calc(100% - ${moveY}px)` }}
+        onClick={(e) => e.stopPropagation()}
       >
-        {/* <div className="hidden mo:block">
-          <div className="mx-auto my-[17px] h-[5px] w-[40px] rounded-full bg-[#d2d2d2]" />
-          <h1 className="border-b py-[11.5px] text-center text-[16px] font-semibold">
-            폴더 이동
-          </h1>
-        </div> */}
-        <div className="mo:border-b mo:p-[20px_18px]">
-          {/* 닫기 버튼 */}
-          <button
-            className="absolute right-[20px]"
-            type="button"
-            onClick={() => {
-              setShowMoveFolderModal(false)
-            }}
-          >
-            <Image
-              src="/image/icon/icon-close.svg"
-              alt="close"
-              width={24}
-              height={24}
-            />
-          </button>
-
-          {/* 타이틀 */}
-          <h1 className="text-[24px] font-semibold">폴더 이동</h1>
-        </div>
-        {/* 폴더 목록 */}
-        <section
+        <div
           className={cn(
-            'h-[410px] w-[380px] divide-y overflow-y-scroll rounded-l-[8px] border border-[#DADADA]',
-            'mo:h-auto mo:w-auto mo:flex-1 mo:border-0',
+            'flex flex-col gap-[25px] p-[26px_46px]',
+            'mo:h-full mo:gap-0 mo:p-0',
           )}
         >
-          {folderList.map((item) => {
-            const { favoriteId, originalName, metadata } = item
-            const { imageUrls } = metadata.folderMetadata
-            return (
-              <div
-                key={favoriteId}
-                onClick={() => {
-                  if (selectFolderId === favoriteId) setSelectFolderId(null)
-                  else setSelectFolderId(favoriteId)
-                }}
-                className={cn(
-                  'flex cursor-pointer items-center gap-[16px] p-[12px_18px]',
-                  {
-                    'bg-[#F1F1F1]': selectFolderId === favoriteId,
-                    'bg-white': selectFolderId !== favoriteId,
-                  },
-                )}
-              >
+          <div ref={ref} className="hidden mo:block">
+            <div className="mx-auto my-[17px] h-[5px] w-[40px] rounded-full bg-[#d2d2d2]" />
+            <h1 className="border-b py-[11.5px] text-center text-[16px] font-semibold">
+              폴더 이동
+            </h1>
+          </div>
+          <div className="mo:hidden mo:border-b">
+            {/* 닫기 버튼 */}
+            <button
+              className="absolute right-[20px]"
+              type="button"
+              onClick={() => {
+                setShowMoveFolderModal(false)
+              }}
+            >
+              <Image
+                src="/image/icon/icon-close.svg"
+                alt="close"
+                width={24}
+                height={24}
+              />
+            </button>
+
+            {/* 타이틀 */}
+            <h1 className="text-[24px] font-semibold">폴더 이동</h1>
+          </div>
+          {/* 폴더 목록 */}
+          <section
+            className={cn(
+              'h-[410px] w-[380px] divide-y overflow-y-scroll rounded-l-[8px] border border-[#DADADA]',
+              'mo:h-auto mo:w-auto mo:flex-1 mo:border-0',
+            )}
+          >
+            {folderList.map((item) => {
+              const { favoriteId, originalName, metadata } = item
+              const { imageUrls } = metadata.folderMetadata
+              return (
                 <div
-                  style={{
-                    backgroundImage:
-                      imageUrls.length > 0 ? `url('${imageUrls[0]}')` : '',
+                  key={favoriteId}
+                  onClick={() => {
+                    if (selectFolderId === favoriteId) setSelectFolderId(null)
+                    else setSelectFolderId(favoriteId)
                   }}
-                  className="h-[52px] w-[52px] rounded-[4px] bg-[#dadada] bg-contain bg-center bg-no-repeat"
-                />
-                <div>{originalName}</div>
-              </div>
-            )
-          })}
-        </section>
+                  className={cn(
+                    'flex cursor-pointer items-center gap-[16px] p-[12px_18px]',
+                    {
+                      'bg-[#F1F1F1]': selectFolderId === favoriteId,
+                      'bg-white': selectFolderId !== favoriteId,
+                    },
+                  )}
+                >
+                  <div
+                    style={{
+                      backgroundImage:
+                        imageUrls.length > 0 ? `url('${imageUrls[0]}')` : '',
+                    }}
+                    className="h-[52px] w-[52px] rounded-[4px] bg-[#dadada] bg-contain bg-center bg-no-repeat"
+                  />
+                  <div>{originalName}</div>
+                </div>
+              )
+            })}
+          </section>
 
-        {/* 하단 버튼 */}
-        <section
-          className={cn(
-            'flex items-center justify-between',
-            'mo:p-[21px_23px]',
-          )}
-        >
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-[10px]"
-            onClick={() => setShowAddFolderModal(true)}
+          {/* 하단 버튼 */}
+          <section
+            className={cn(
+              'flex items-center justify-between',
+              'mo:p-[21px_23px]',
+            )}
           >
-            <Image
-              src="/image/icon/icon-add_circle.svg"
-              width={36}
-              height={36}
-              alt="add"
-            />
-            <span className="text-[16px] font-semibold">새 폴더</span>
-          </button>
-          <button
-            type="button"
-            disabled={!selectFolderId}
-            onClick={handleMoveItems}
-            className="rounded-full bg-black p-[10px_27px] text-white disabled:bg-[#b1b1b1]"
-          >
-            이동하기
-          </button>
-        </section>
+            <button
+              type="button"
+              className="flex cursor-pointer items-center gap-[10px]"
+              onClick={() => setShowAddFolderModal(true)}
+            >
+              <Image
+                src="/image/icon/icon-add_circle.svg"
+                width={36}
+                height={36}
+                alt="add"
+              />
+              <span className="text-[16px] font-semibold">새 폴더</span>
+            </button>
+            <button
+              type="button"
+              disabled={!selectFolderId}
+              onClick={handleMoveItems}
+              className="rounded-full bg-black p-[10px_27px] text-white disabled:bg-[#b1b1b1]"
+            >
+              이동하기
+            </button>
+          </section>
+        </div>
       </div>
-    </Modal>
+    </div>
   )
 }

--- a/src/app/(route)/(withLayout)/saves/_component/MoveFolderModal.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/MoveFolderModal.tsx
@@ -35,7 +35,7 @@ export default function MoveFolderModal(props: Props) {
   const [moveY, setMoveY] = useState(0)
   const [endY, setEndY] = useState(0)
 
-  const ref: any = useRef(null)
+  const ref = useRef<HTMLDivElement>(null)
 
   const onTouchStart = (e: TouchEvent) => {
     setStartY(e.touches[0].clientY)

--- a/src/app/(route)/(withLayout)/saves/_component/SaveComponent.tsx
+++ b/src/app/(route)/(withLayout)/saves/_component/SaveComponent.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import React, { useState } from 'react'
-import { SaveFolderType } from '@/app/_types/save.type'
+import React, { useEffect, useState } from 'react'
+import { SaveFolderType, SavePageMode } from '@/app/_types/save.type'
 import useSaveList from '@/app/_hook/api/saves/useSavesList'
 import { cn } from '@/app/_utils/twMerge'
+import { useSetRecoilState } from 'recoil'
+import { saveModeState } from '@/app/_atoms/saveModeState'
 
 import { SaveHeader } from './SaveHeader'
 import SaveList from './SaveList'
@@ -11,8 +13,16 @@ import AddFolderModal from './AddFolderModal'
 
 export default function SaveComponent() {
   const [showAddFolderModal, setShowAddFolderModal] = useState(false)
+  const setMode = useSetRecoilState(saveModeState)
 
   const { saveInfo, isLoading, isError } = useSaveList('all')
+
+  useEffect(
+    function resetMode() {
+      setMode(SavePageMode.DEFAULT)
+    },
+    [setMode],
+  )
 
   if (isLoading) return <div>...loading</div>
   if (isError) return null

--- a/src/app/(route)/(withLayout)/saves/_utils/validation.ts
+++ b/src/app/(route)/(withLayout)/saves/_utils/validation.ts
@@ -1,0 +1,17 @@
+import renderToast from '@/app/_utils/toast'
+
+export const validateSaveFolderName = (folderName: string): boolean => {
+  if (folderName === 'default') {
+    renderToast({ type: 'error', message: '생성 불가능한 이름입니다.' })
+    return false
+  }
+  if (folderName.length > 20 || folderName.length === 0) {
+    renderToast({
+      type: 'error',
+      message: '1-20자로 설정해주세요.',
+    })
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## 1. Changes

1. 찜 폴더 이름 설정 관련 Validation Toast 추가
2. 목록 편집 모드 유지되는 현상 수정
3. 모바일 찜 폴더 이동 모달에 드래그 이벤트 추가

## 2. Screenshot

### 1. 찜 폴더 이름 설정 관련 Validation Toast 추가
![Apr-01-2024 14-08-41](https://github.com/uju-in/lime-frontend/assets/58348662/c3417fdd-3587-4503-a843-d8b437548f3b)

### 2. 목록 편집 모드 유지되는 현상 수정
### - 수정 전
![Apr-01-2024 14-10-57](https://github.com/uju-in/lime-frontend/assets/58348662/cd3a600e-d383-4662-b581-1f511dfb3f93)
### - 수정 후
![Apr-01-2024 14-11-08](https://github.com/uju-in/lime-frontend/assets/58348662/9b08def2-b775-4abd-a879-437092a4e814)



### 3. 모바일 찜 폴더 이동 모달에 드래그 이벤트 추가
![Apr-01-2024 14-07-17](https://github.com/uju-in/lime-frontend/assets/58348662/9a837676-78c5-414b-ad7d-2c3efa36f066)



## 3. Issues

1. #49 Issue 2번에 적은 내용 구현했는데, Modal에 inline style을 넣어야돼서 (height 값으로 변수 값을 사용해야 함) `<Modal />` 공용 컴포넌트를 사용하지 않고 따로 구현하였습니다. 참고 부탁드립니다! - [관련 커밋](1004a9be16b5f3b27917c43eae592e3ed92a02f7)

```typescript
style={{ height: `calc(100% - ${moveY}px)` }}
```

2. [fix: 목록편집 모드 유지되는 현상 수정](https://github.com/uju-in/lime-frontend/commit/29161a080305531469d188a44ae723fa6e0b617f) - 이전 PR에서 목록 편집 모드 상태 값을 Recoil로 관리하도록 변경했는데, 해당 작업을 하면서 발생한 문제인 것 같습니다. 찜 목록 페이지(/saves) 진입 시 `useEffect` 로 모드를 초기화하는 코드를 넣어 해결했는데, `useEffect`의 사용을 지양하는 것이 좋으니 더 좋은 방법이 있으면 공유 부탁드립니다!

## 4. To Reviewer

- @mintmin0320 
- 위에 작성한 이슈만 확인해주시면 될 것 같고, 모달 드래그 이벤트의 경우 모바일 기기에서만 동작하도록 구현되어 있으니 참고 부탁드립니다! (PC 반응형은 동작 X - PC는 TouchEvent가 아닌 MouseEvent라서)

## 5. Plans

- [ ] -
- [ ] -
