### PR TITLE
feat: 권한별 페이지 리다이렉트 처리 구현

### DIFF
--- a/src/app/_constants/error.ts
+++ b/src/app/_constants/error.ts
@@ -1,0 +1,9 @@
+export const ERROR_MESSAGE = {
+  PROFILE_COMPLETION_REQUIRED: '프로필 작성이 필요한 서비스입니다.',
+  LOGIN_REQUIRED: '로그인이 필요한 서비스입니다.',
+}
+
+export const ERROR_CODE = {
+  INVALID_ACCESS_TOKEN: 'COMMON_009',
+  INSUFFICIENT_PERMISSION: 'MEMBER_017',
+}

--- a/src/app/_hook/api/auth/useTokenValidity.ts
+++ b/src/app/_hook/api/auth/useTokenValidity.ts
@@ -9,5 +9,11 @@ export async function fetchTokenValidity(accessToken: string) {
     },
   )
 
+  const data = await res.json()
+
+  if (!res.ok) {
+    throw data
+  }
+
   return res.ok
 }

--- a/src/app/_hook/api/items/useAddItem.ts
+++ b/src/app/_hook/api/items/useAddItem.ts
@@ -3,6 +3,7 @@ import { ItemState } from '@/app/_types/addItem.type'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { itemKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function postAddItem(params: ItemState) {
   const accessToken = getCookie('accessToken')
@@ -19,10 +20,10 @@ async function postAddItem(params: ItemState) {
     },
   )
 
-  const data = await res.json()
-
   if (!res.ok) {
-    throw data.message
+    const data = await res.json()
+
+    throw data
   }
 
   return res.status
@@ -30,8 +31,9 @@ async function postAddItem(params: ItemState) {
 
 export default function useAddItem() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
-  return useMutation<number, unknown, ItemState>({
+  return useMutation<number, Error, ItemState>({
     mutationFn: postAddItem,
     onSuccess: () => {
       renderToast({
@@ -42,10 +44,7 @@ export default function useAddItem() {
       queryClient.invalidateQueries({ queryKey: itemKeys.itemList._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/items/useItemListData.ts
+++ b/src/app/_hook/api/items/useItemListData.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { ItemType } from '@/app/_types/item.type'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'

--- a/src/app/_hook/api/items/useSaveToWishlist.ts
+++ b/src/app/_hook/api/items/useSaveToWishlist.ts
@@ -2,6 +2,7 @@ import renderToast from '@/app/_utils/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCookie } from 'cookies-next'
 import { itemKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function postSaveToWishlist(itemIds: number[]): Promise<void> {
   const accessToken = getCookie('accessToken')
@@ -22,12 +23,13 @@ async function postSaveToWishlist(itemIds: number[]): Promise<void> {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 }
 
 export default function useAddFavorites() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, number[]>({
     mutationFn: postSaveToWishlist,
@@ -40,10 +42,7 @@ export default function useAddFavorites() {
       queryClient.invalidateQueries({ queryKey: itemKeys.itemDetail._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/reviews/useAddReview.ts
+++ b/src/app/_hook/api/reviews/useAddReview.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { reviewKeys } from '.'
 import { itemKeys } from '../items'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 interface AddReviewRequest {
   itemId: number
@@ -21,10 +21,10 @@ async function postAddReview({ formData }: AddReviewRequest) {
     body: formData,
   })
 
-  const data = await res.json()
-
   if (!res.ok) {
-    throw data.message
+    const data = await res.json()
+
+    throw data
   }
 
   return res.status
@@ -32,6 +32,7 @@ async function postAddReview({ formData }: AddReviewRequest) {
 
 export default function useAddReview() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, AddReviewRequest>({
     mutationFn: ({ itemId, formData }) => postAddReview({ itemId, formData }),
@@ -47,10 +48,7 @@ export default function useAddReview() {
       queryClient.invalidateQueries({ queryKey: itemKeys.itemDetail._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/reviews/useDeleteReview.ts
+++ b/src/app/_hook/api/reviews/useDeleteReview.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { reviewKeys } from '.'
 import { itemKeys } from '../items'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function deleteReview(reviewId: number) {
   const accessToken = getCookie('accessToken')
@@ -21,12 +21,13 @@ async function deleteReview(reviewId: number) {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 }
 
 export default function useDeleteReview() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, number>({
     mutationFn: (reviewId) => deleteReview(reviewId),
@@ -44,10 +45,7 @@ export default function useDeleteReview() {
       })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/reviews/useEditReview.ts
+++ b/src/app/_hook/api/reviews/useEditReview.ts
@@ -3,6 +3,7 @@ import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { reviewKeys } from '.'
 import { itemKeys } from '../items'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 interface EditReviewRequest {
   reviewId: number
@@ -26,7 +27,7 @@ async function postReviewData({ reviewId, formData }: EditReviewRequest) {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 
   return res.status
@@ -34,6 +35,7 @@ async function postReviewData({ reviewId, formData }: EditReviewRequest) {
 
 export default function useEditReview() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, EditReviewRequest>({
     mutationFn: ({ reviewId, formData }) =>
@@ -48,10 +50,7 @@ export default function useEditReview() {
       queryClient.invalidateQueries({ queryKey: itemKeys.itemDetail._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/reviews/useReviewLikeAction.ts
+++ b/src/app/_hook/api/reviews/useReviewLikeAction.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { reviewKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 interface ReviewLikeRequest {
   reviewId: number
@@ -24,12 +24,13 @@ async function postReviewLikeAction({ reviewId, isLiked }: ReviewLikeRequest) {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 }
 
 export default function useReviewLikeAction() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, ReviewLikeRequest>({
     mutationFn: ({ reviewId, isLiked }) =>
@@ -38,10 +39,7 @@ export default function useReviewLikeAction() {
       queryClient.invalidateQueries({ queryKey: reviewKeys.reviewList._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/saves/useAddSaveFolder.ts
+++ b/src/app/_hook/api/saves/useAddSaveFolder.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { saveKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 const addSaveFolder = async (folderName: string) => {
   const accessToken = getCookie('accessToken')
@@ -27,6 +28,7 @@ const addSaveFolder = async (folderName: string) => {
 
 export default function useAddSaveFolder() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, string>({
     mutationFn: (folderName) => addSaveFolder(folderName),
@@ -36,7 +38,7 @@ export default function useAddSaveFolder() {
       queryClient.invalidateQueries({ queryKey: saveKeys.saveList._def })
     },
     onError: (error) => {
-      renderToast({ type: 'error', message: String(error) })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/saves/useChangeSaveFolderName.ts
+++ b/src/app/_hook/api/saves/useChangeSaveFolderName.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { saveKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 interface ChangeSaveFolderRequest {
   folderId: number
@@ -29,7 +30,7 @@ async function postChangeName({
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 
   return res.status
@@ -37,6 +38,7 @@ async function postChangeName({
 
 export const useChangeSaveFolderName = () => {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, ChangeSaveFolderRequest>({
     mutationFn: ({ folderId, folderName }) =>
@@ -47,7 +49,7 @@ export const useChangeSaveFolderName = () => {
       queryClient.invalidateQueries({ queryKey: saveKeys.saveList._def })
     },
     onError: (error) => {
-      renderToast({ type: 'error', message: String(error) })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/saves/useDeleteSave.ts
+++ b/src/app/_hook/api/saves/useDeleteSave.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { saveKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function deleteSave(favoriteItemIds: number[], folderIds: number[]) {
   const accessToken = getCookie('accessToken')
@@ -24,7 +24,7 @@ async function deleteSave(favoriteItemIds: number[], folderIds: number[]) {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 }
 
@@ -35,6 +35,7 @@ interface DeleteSaveRequest {
 
 export default function useDeleteSave() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, DeleteSaveRequest>({
     mutationFn: ({ favoriteItemIds, folderIds }) =>
@@ -45,7 +46,7 @@ export default function useDeleteSave() {
       queryClient.invalidateQueries({ queryKey: saveKeys.saveList._def })
     },
     onError: (error) => {
-      renderToast({ type: 'error', message: String(error) })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/saves/useMoveSaveItems.ts
+++ b/src/app/_hook/api/saves/useMoveSaveItems.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { saveKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 export interface MoveSaveItemsRequest {
   folderId?: number
@@ -29,7 +30,7 @@ async function postMoveSaveItems({
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 
   return res.status
@@ -37,6 +38,7 @@ async function postMoveSaveItems({
 
 export default function useMoveSaveItems() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, MoveSaveItemsRequest>({
     mutationFn: ({ folderId, favoriteItemIds }) =>
@@ -47,7 +49,7 @@ export default function useMoveSaveItems() {
       queryClient.invalidateQueries({ queryKey: saveKeys.saveList._def })
     },
     onError: (error) => {
-      renderToast({ type: 'error', message: String(error) })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/votes/useAddVote.ts
+++ b/src/app/_hook/api/votes/useAddVote.ts
@@ -3,6 +3,7 @@ import { VoteInfoType } from '@/app/_types/addVote.type'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { voteKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function postAddItem(params: VoteInfoType) {
   const accessToken = getCookie('accessToken')
@@ -19,7 +20,7 @@ async function postAddItem(params: VoteInfoType) {
   if (!res.ok) {
     const data = await res.json()
 
-    throw data.message
+    throw data
   }
 
   return res.status
@@ -27,6 +28,7 @@ async function postAddItem(params: VoteInfoType) {
 
 export default function useAddVote() {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, VoteInfoType>({
     mutationFn: postAddItem,
@@ -40,10 +42,7 @@ export default function useAddVote() {
       queryClient.invalidateQueries({ queryKey: voteKeys.voteRanking._def })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/votes/useDeleteVote.ts
+++ b/src/app/_hook/api/votes/useDeleteVote.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import renderToast from '@/app/_utils/toast'
 import { getCookie } from 'cookies-next'
 import { voteKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function deleteVote(voteId: number): Promise<number> {
   const accessToken = getCookie('accessToken')
@@ -20,7 +21,7 @@ async function deleteVote(voteId: number): Promise<number> {
   if (!res.ok) {
     const data = await res.json()
 
-    throw Error(data.message)
+    throw data
   }
 
   return res.status
@@ -28,6 +29,7 @@ async function deleteVote(voteId: number): Promise<number> {
 
 export const useDeleteVote = () => {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, number>({
     mutationFn: (voidId) => deleteVote(voidId),
@@ -45,10 +47,7 @@ export const useDeleteVote = () => {
       })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/votes/useFavoritesList.ts
+++ b/src/app/_hook/api/votes/useFavoritesList.ts
@@ -26,7 +26,7 @@ export async function fetchFavoriteList({ type, folderId }: RequestInfo) {
   const data = await res.json()
 
   if (!res.ok) {
-    throw new Error(data.message)
+    return data
   }
 
   return data

--- a/src/app/_hook/api/votes/useParticipationVote.ts
+++ b/src/app/_hook/api/votes/useParticipationVote.ts
@@ -2,6 +2,7 @@ import renderToast from '@/app/_utils/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCookie } from 'cookies-next'
 import { voteKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 interface VoteItemRequest {
   itemId: number | null
@@ -27,7 +28,7 @@ async function voteItem({ itemId, voteId }: VoteItemRequest): Promise<number> {
   if (!res.ok) {
     const data = await res.json()
 
-    throw Error(data.message)
+    throw data
   }
 
   return res.status
@@ -35,6 +36,7 @@ async function voteItem({ itemId, voteId }: VoteItemRequest): Promise<number> {
 
 export const useParticipationVote = () => {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<number, Error, VoteItemRequest>({
     mutationFn: ({ itemId, voteId }) => voteItem({ itemId, voteId }),
@@ -55,10 +57,7 @@ export const useParticipationVote = () => {
       })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/api/votes/useReParticipation.ts
+++ b/src/app/_hook/api/votes/useReParticipation.ts
@@ -2,6 +2,7 @@ import renderToast from '@/app/_utils/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCookie } from 'cookies-next'
 import { voteKeys } from '.'
+import { useHandleApiError } from '../../common/useHandleApiError'
 
 async function reVote(voteId: number): Promise<void> {
   const accessToken = getCookie('accessToken')
@@ -27,6 +28,7 @@ async function reVote(voteId: number): Promise<void> {
 
 export const useReParticipation = () => {
   const queryClient = useQueryClient()
+  const handleApiError = useHandleApiError()
 
   return useMutation<void, Error, number>({
     mutationFn: (voidId) => reVote(voidId),
@@ -47,10 +49,7 @@ export const useReParticipation = () => {
       })
     },
     onError: (error) => {
-      renderToast({
-        type: 'error',
-        message: String(error),
-      })
+      handleApiError(error)
     },
   })
 }

--- a/src/app/_hook/common/useHandleApiError.ts
+++ b/src/app/_hook/common/useHandleApiError.ts
@@ -11,19 +11,25 @@ export const useHandleApiError = () => {
   const router = useRouter()
 
   return (error: ApiError) => {
-    if (error.code === ERROR_CODE.INSUFFICIENT_PERMISSION) {
-      if (window.confirm(ERROR_MESSAGE.PROFILE_COMPLETION_REQUIRED)) {
-        router.push('/join')
-      }
-    } else if (error.code === ERROR_CODE.INVALID_ACCESS_TOKEN) {
-      if (window.confirm(ERROR_MESSAGE.LOGIN_REQUIRED)) {
-        router.push('/login')
-      }
-    } else {
-      renderToast({
-        type: 'error',
-        message: String(error.message),
-      })
+    switch (error.code) {
+      case ERROR_CODE.INSUFFICIENT_PERMISSION:
+        if (window.confirm(ERROR_MESSAGE.PROFILE_COMPLETION_REQUIRED)) {
+          router.push('/join')
+        }
+        break
+
+      case ERROR_CODE.INVALID_ACCESS_TOKEN:
+        if (window.confirm(ERROR_MESSAGE.LOGIN_REQUIRED)) {
+          router.push('/login')
+        }
+        break
+
+      default:
+        renderToast({
+          type: 'error',
+          message: String(error.message),
+        })
+        break
     }
   }
 }

--- a/src/app/_hook/common/useHandleApiError.ts
+++ b/src/app/_hook/common/useHandleApiError.ts
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/navigation'
+import { ERROR_CODE, ERROR_MESSAGE } from '@/app/_constants/error'
+import renderToast from '../../_utils/toast'
+
+interface ApiError extends Error {
+  code?: string
+  message: string
+}
+
+export const useHandleApiError = () => {
+  const router = useRouter()
+
+  return (error: ApiError) => {
+    if (error.code === ERROR_CODE.INSUFFICIENT_PERMISSION) {
+      if (window.confirm(ERROR_MESSAGE.PROFILE_COMPLETION_REQUIRED)) {
+        router.push('/join')
+      }
+    } else if (error.code === ERROR_CODE.INVALID_ACCESS_TOKEN) {
+      if (window.confirm(ERROR_MESSAGE.LOGIN_REQUIRED)) {
+        router.push('/login')
+      }
+    } else {
+      renderToast({
+        type: 'error',
+        message: String(error.message),
+      })
+    }
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,27 +1,58 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchTokenValidity } from './app/_hook/api/auth/useTokenValidity'
+import { ERROR_CODE } from './app/_constants/error'
+
+interface ApiError {
+  code?: string
+  message: string
+}
 
 export async function middleware(request: NextRequest) {
-  const accessToken = request.cookies.get('accessToken')?.value ?? ''
-
-  const isValidToken = accessToken
-    ? await fetchTokenValidity(accessToken)
-    : false
-
   const url = new URL(request.url)
   const currentPath = url.pathname
+  const accessToken = request.cookies.get('accessToken')?.value ?? ''
 
-  const redirectToLogin =
-    ['/mypage', '/saves'].some((path) => currentPath.startsWith(path)) &&
+  // 접근 제한이 필요한 경로
+  const protectedPaths = [
+    '/mypage',
+    '/saves',
+    '/items/add-item',
+    '/votes/add-vote',
+  ]
+  const authPaths = ['/login', '/join']
+
+  // 현재 경로가 로그인이나 회원가입 경로에 있을 경우, 추가 처리 없이 요청을 계속 진행
+  if (authPaths.includes(currentPath)) {
+    return NextResponse.next()
+  }
+
+  let isValidToken = false
+
+  try {
+    isValidToken = accessToken ? await fetchTokenValidity(accessToken) : false
+
+    if (!isValidToken) {
+      return NextResponse.redirect(new URL('/login', request.url))
+    }
+  } catch (error: unknown) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as ApiError).code === ERROR_CODE.INSUFFICIENT_PERMISSION
+    ) {
+      return NextResponse.redirect(new URL('/join', request.url))
+    }
+  }
+
+  if (
+    protectedPaths.some((path) => currentPath.startsWith(path)) &&
     !isValidToken
-  const redirectToHome =
-    ['/login', '/join'].includes(currentPath) && isValidToken
-
-  if (redirectToLogin) {
+  ) {
     return NextResponse.redirect(new URL('/login', request.url))
   }
 
-  if (redirectToHome) {
+  if (authPaths.includes(currentPath) && isValidToken) {
     return NextResponse.redirect(new URL('/', request.url))
   }
 
@@ -29,5 +60,13 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/mypage', '/login', '/join', '/saves', '/saves/:path*'],
+  matcher: [
+    '/mypage',
+    '/login',
+    '/join',
+    '/saves',
+    '/saves/:path*',
+    '/items/add-item',
+    '/votes/add-vote',
+  ],
 }


### PR DESCRIPTION
## 1. Changes

- 리뷰 더 보기 버튼 표시 조건 추가
- 에러 처리 핸들러 추가 및 적용
- 권한별 페이지 리다이렉트 추가
로그인 -> 프로필 미작성 -> 특정 기능(투표, 아이템 찜 등) 이용, 특정 페이지(마이페이지, 찜 등) 접속 -> 프로필 페이지 리다이렉트
로그인 X -> 특정 기능, 페이지 접속 시 로그인 페이지로 리다이렉트

<br/>

## 2. Screenshot
### 프로필 작성 X
![화면-기록-2024-04-05-오후-10 24 19](https://github.com/uju-in/lime-frontend/assets/114549939/0df878c9-d38e-44a5-afa6-e94bbc3cd96b)

### 로그인 X
![화면-기록-2024-04-05-오후-10 24 44](https://github.com/uju-in/lime-frontend/assets/114549939/20ad735b-67ba-4ce4-aefe-f2ce032502a8)

<br/>

## 3. Issues

## 4. To Reviewer

@yeeeerim 
큰 이슈는 없었습니다!
middleware 파일에서 접속 시 토큰의 유효성을 검사해 페이지 리다이렉트를 처리했습니다!

<br/>

## 5. Plans