### PR TITLE
fix: 회원가입 버튼 문구 수정 및 피드 주석 처리

### DIFF
--- a/src/app/(route)/(withoutLayout)/join/_components/UserInfoForm.tsx
+++ b/src/app/(route)/(withoutLayout)/join/_components/UserInfoForm.tsx
@@ -109,7 +109,7 @@ export default function UserInfoForm({
           className="flex h-[48px] w-full items-center justify-center rounded-[4px] bg-black font-[600] text-white"
           type="submit"
         >
-          회원가입
+          완료
         </button>
       </div>
     </form>

--- a/src/app/_components/layout/Header.tsx
+++ b/src/app/_components/layout/Header.tsx
@@ -33,10 +33,10 @@ export default async function Header() {
         </div>
         {/* 카테고리 */}
         <ul className="flex gap-[80px] text-[18px]">
-          <li className="font-bold">
-            {/* TODO: href 변경 */}
+          {/* TODO: 개발 전 주석 처리 */}
+          {/* <li className="font-bold">
             <Link href="/">피드</Link>
-          </li>
+          </li> */}
           <li className="font-bold">
             <Link href="/votes">투표</Link>
           </li>

--- a/src/app/_components/layout/mobile/MoNavbar.tsx
+++ b/src/app/_components/layout/mobile/MoNavbar.tsx
@@ -5,7 +5,8 @@ import { useRouter, usePathname } from 'next/navigation'
 import React from 'react'
 
 const NavList = [
-  { label: '피드', url: '/feeds' },
+  // TODO: 개발 전 주석 처리
+  // { label: '피드', url: '/feeds' },
   { label: '투표', url: '/votes' },
   { label: '홈', url: '/' },
   { label: '아이템', url: '/items' },


### PR DESCRIPTION
## 1. Changes

1. 회원가입 버튼 문구 수정  : `회원가입` -> `완료` (프로필 편집에서도 공용으로 사용하기 위함)
2. 네비게이션 바에서 피드 주석 처리

## 2. Screenshot

<img width="575" alt="image" src="https://github.com/uju-in/lime-frontend/assets/58348662/b0900800-4a99-4856-ae89-cba6a1189454">

<img width="728" alt="image" src="https://github.com/uju-in/lime-frontend/assets/58348662/45d7ca37-99ac-406d-bd7e-072734327abb">

<img width="420" alt="image" src="https://github.com/uju-in/lime-frontend/assets/58348662/524bc765-5ed9-492c-9356-56c23eb207dd">

## 3. Issues


## 4. To Reviewer

- @mintmin0320 

내용만 확인하시고 다른 의견 없으시면 바로 병합 부탁드립니다!

## 5. Plans

- [ ] -
- [ ] -
