### PR TITLE
refactor: 투표 아이템 선택 모달 리팩토링

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "jsx-a11y/no-static-element-interactions": "off",
     "no-underscore-dangle": "off",
     "global-require": "off",
-    "react/destructuring-assignment": "off"
+    "react/destructuring-assignment": "off",
+    "react/jsx-props-no-spreading": "off"
   }
 }

--- a/src/app/(route)/(withLayout)/layout.tsx
+++ b/src/app/(route)/(withLayout)/layout.tsx
@@ -1,7 +1,9 @@
+import RQProvider from '@/app/_components/RQProvider'
 import Footer from '@/app/_components/layout/Footer'
 import Header from '@/app/_components/layout/Header'
 import SearchHeader from '@/app/_components/layout/search/SearchHeader'
-import React, { ReactNode } from 'react'
+import ModalContainer from '@/app/_components/modalContainer'
+import { ReactNode } from 'react'
 import HomeHeader from './_components/HomeHeader'
 
 export default function WithLayout({ children }: { children: ReactNode }) {
@@ -10,7 +12,12 @@ export default function WithLayout({ children }: { children: ReactNode }) {
       <SearchHeader />
       <Header />
       <HomeHeader />
-      <div className="mb-[18px]">{children}</div>
+      <div className="mb-[18px]">
+        <RQProvider>
+          {children}
+          <ModalContainer />
+        </RQProvider>
+      </div>
       <Footer />
     </main>
   )

--- a/src/app/(route)/(withLayout)/votes/[voteId]/_component/FavoritesVoteItem.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/_component/FavoritesVoteItem.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import { ItemInfoType } from '@/app/_types/detailVote.type'
 import { cn } from '@/app/_utils/twMerge'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 import { truncateString } from '../../_utils/truncateString'
 
 interface PropsType {
@@ -18,12 +18,12 @@ export default function FavoritesVoteItem(props: PropsType) {
   const router = useRouter()
 
   return (
-    <div
+    <article
       className={cn(
         'relative',
         'mo:flex:1 border-black mo:rounded-[6px] mo:border-[2px]',
         {
-          'border-0 border-[3px]': id === itemId,
+          'border-[3px]': id === itemId,
         },
       )}
       onClick={() => onSelectItem(id)}
@@ -35,6 +35,7 @@ export default function FavoritesVoteItem(props: PropsType) {
         alt="item1 image"
         className="mo:rounded-[6px]"
         loading="eager"
+        priority
       />
       <div
         className={cn(
@@ -46,9 +47,9 @@ export default function FavoritesVoteItem(props: PropsType) {
           },
         )}
       >
-        <p className="mb-[15.4px] h-[65px] text-center text-[14px] font-[500]">
+        <strong className="mb-[15.4px] h-[65px] text-center text-[14px] font-[500]">
           <strong>{truncateString(name, 35)}</strong>
-        </p>
+        </strong>
         <strong className="text-[14px] font-[700]">
           {price.toLocaleString()}원
         </strong>
@@ -75,6 +76,6 @@ export default function FavoritesVoteItem(props: PropsType) {
           </button>
         </div>
       </div>
-    </div>
+    </article>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteInfo.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteInfo.tsx
@@ -1,11 +1,11 @@
 'use client'
 
+import { VoteDetailType } from '@/app/_types/detailVote.type'
 import { categoryFormatter } from '@/app/_utils/categoryFormatter'
 import { dateFormatter } from '@/app/_utils/dateFormatter'
 import { cn } from '@/app/_utils/twMerge'
-import { VoteDetailType } from '@/app/_types/detailVote.type'
-import VoteProgressTracker from './VoteProgressTracker'
 import ManagementButton from './ManagementButton'
+import VoteProgressTracker from './VoteProgressTracker'
 
 export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
   const { isOwner, voteInfo } = voteData
@@ -26,6 +26,7 @@ export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
         ' mo:w-full mo:border-0 mo:px-[16px]',
       )}
     >
+      {/** 카테고리  */}
       <div className="flex justify-between text-center text-[12px] font-[500]">
         <div className="flex gap-[6px]">
           <div
@@ -45,14 +46,18 @@ export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
             {hobby}
           </div>
         </div>
+        {/** 작성자 관리 버튼  */}
         {isOwner && <ManagementButton voteId={id} />}
       </div>
       <div className={cn('mt-[18px] flex', 'mo:mt-[8px]')}>
         <span className="flex h-[17px] gap-[4px] text-[12px] font-[500] text-[#747474]">
-          {dateFormatter(startTime)} · 투표인원 {maxParticipants}명
+          <time dateTime={new Date(startTime).toISOString()}>
+            {dateFormatter(startTime)}
+          </time>
+          · 투표인원 {maxParticipants}명
         </span>
       </div>
-      <p className="mt-[26px] text-[14px] font-[500]">{content}</p>
+      <p className="mt-[14px] break-all text-[14px] font-[500]">{content}</p>
       <div className={cn('block', 'mo:hidden')}>
         <VoteProgressTracker endTime={endTime} participants={participants} />
       </div>

--- a/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteItemCard.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteItemCard.tsx
@@ -12,7 +12,7 @@ interface PropsType {
   onSelectItem: (selectItemId: number) => void
 }
 
-export default function FavoritesVoteItem(props: PropsType) {
+export default function VoteItemCard(props: PropsType) {
   const { itemId, voteItemInfo, onSelectItem } = props
   const { id, image, name, price } = voteItemInfo
   const router = useRouter()

--- a/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteItemInfo.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteItemInfo.tsx
@@ -6,8 +6,8 @@ import { VoteDetailType } from '@/app/_types/detailVote.type'
 import { cn } from '@/app/_utils/twMerge'
 import { useCallback, useState } from 'react'
 import { validateChoiceItem } from '../_utils/validation'
-import VoteItem from './FavoritesVoteItem'
 import ProgressBar from './ProgressBar'
+import VoteItemCard from './VoteItemCard'
 import VoteProgressTracker from './VoteProgressTracker'
 
 export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
@@ -70,7 +70,7 @@ export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
           )}
         >
           {/** item1 */}
-          <VoteItem
+          <VoteItemCard
             voteItemInfo={item1Info}
             itemId={itemId}
             onSelectItem={handleSelectItem}
@@ -82,7 +82,7 @@ export default function VoteInfo({ voteData }: { voteData: VoteDetailType }) {
             )}
           />
           {/** item2 */}
-          <VoteItem
+          <VoteItemCard
             voteItemInfo={item2Info}
             itemId={itemId}
             onSelectItem={handleSelectItem}

--- a/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteProgressTracker.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/_component/VoteProgressTracker.tsx
@@ -13,12 +13,16 @@ export default function VoteProgressTracker({
 }: PropsType) {
   return (
     <>
-      <p className="mt-[15px] text-[12px] font-[500] text-[#9C9C9C]">
-        {detailDateFormatter(endTime)} 투표 마감
-      </p>
-      <p className="text-[12px] font-[500] text-[#9C9C9C]">
+      <span className="mt-[15px] text-[12px] font-[500] text-[#9C9C9C]">
+        <time dateTime={new Date(endTime).toISOString()}>
+          {detailDateFormatter(endTime)}
+        </time>
+        투표 마감
+      </span>
+      <br />
+      <span className="text-[12px] font-[500] text-[#9C9C9C]">
         {participants}명 참여중
-      </p>
+      </span>
     </>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/[voteId]/layout.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/layout.tsx
@@ -6,9 +6,9 @@ export default function DetailItemLayout({
   children: React.ReactNode
 }) {
   return (
-    <main className="flex h-dvh justify-center">
+    <section className="flex h-dvh justify-center">
       <MoDetailVoteHeader />
       {children}
-    </main>
+    </section>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/[voteId]/page.tsx
+++ b/src/app/(route)/(withLayout)/votes/[voteId]/page.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@/app/_utils/twMerge'
-import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
 import ErrorFallback from '@/app/_components/errorFallback'
+import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
 import Loading from '@/app/_components/loading'
+import { cn } from '@/app/_utils/twMerge'
 import VoteDetail from './_component/VoteDetail'
 
 type Props = {
@@ -12,13 +12,13 @@ export default function pages({ params }: Props) {
   const { voteId } = params
 
   return (
-    <section className={cn('mx-auto min-h-[900px] w-[720px]', ' mo:w-full')}>
+    <main className={cn('min-h-[900px] w-[720px]', ' mo:w-full')}>
       <ErrorHandlingWrapper
         fallbackComponent={ErrorFallback}
         suspenseFallback={<Loading />}
       >
         <VoteDetail voteId={voteId} />
       </ErrorHandlingWrapper>
-    </section>
+    </main>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/_component/RankingList.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/RankingList.tsx
@@ -12,6 +12,11 @@ export default function RankingList() {
   const { rankingList } = useVoteRanking(hobby)
   const { rankingInfos } = rankingList
 
+  // 투표 랭킹 아이템이 없을 경우
+  if (rankingInfos.length < 0) {
+    return <div className="h-[104px]" />
+  }
+
   return (
     <article className={cn('mt-[52px] w-full', 'mo:pl-[16px]')}>
       <h1 className="text-[26px] font-[700]">투표 랭킹</h1>
@@ -21,32 +26,27 @@ export default function RankingList() {
           'mo:gap-[12px] mo:overflow-x-scroll',
         )}
       >
-        {rankingInfos.length > 0 ? (
-          rankingInfos.map((item) => (
-            <li key={item.id} className="cursor-pointer text-center">
-              <Link href={`/votes/${item.id}`} className="block h-full w-full">
-                <div className="flex h-[104px] w-[104px] items-center justify-center rounded-full border-[2px] border-[#D9D9D9]">
-                  <figure className="flex h-[93px] w-[93px] rounded-full border">
-                    <VoteImage
-                      src={item.item1Image}
-                      innerClassNames="rounded-l-full"
-                    />
-                    <VoteImage
-                      src={item.item2Image}
-                      innerClassNames="rounded-r-full"
-                    />
-                  </figure>
-                </div>
-                <span className="mt-[11.4px] text-[14.2px] font-[500] text-[#5D5D5D]">
-                  {item.participants}명 참여중
-                </span>
-              </Link>
-            </li>
-          ))
-        ) : (
-          // 투표 랭킹 아이템이 없을 경우
-          <div className="h-[104px]" />
-        )}
+        {rankingInfos.map((item) => (
+          <li key={item.id} className="cursor-pointer text-center">
+            <Link href={`/votes/${item.id}`}>
+              <div className="flex h-[104px] w-[104px] items-center justify-center rounded-full border-[2px] border-[#D9D9D9]">
+                <figure className="flex h-[93px] w-[93px] rounded-full border">
+                  <VoteImage
+                    src={item.item1Image}
+                    innerClassNames="rounded-l-full"
+                  />
+                  <VoteImage
+                    src={item.item2Image}
+                    innerClassNames="rounded-r-full"
+                  />
+                </figure>
+              </div>
+              <span className="mt-[11.4px] text-[14.2px] font-[500] text-[#5D5D5D]">
+                {item.participants}명 참여중
+              </span>
+            </Link>
+          </li>
+        ))}
       </ul>
     </article>
   )

--- a/src/app/(route)/(withLayout)/votes/_component/RankingList.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/RankingList.tsx
@@ -3,8 +3,8 @@
 import { useVoteRanking } from '@/app/_hook/api/votes/queries/useVoteRanking'
 import useGetSearchParam from '@/app/_hook/common/useGetSearchParams'
 import { cn } from '@/app/_utils/twMerge'
-import Image from 'next/image'
 import Link from 'next/link'
+import VoteImage from './VoteImage'
 
 export default function RankingList() {
   const hobby = useGetSearchParam('category') || '농구'
@@ -13,48 +13,41 @@ export default function RankingList() {
   const { rankingInfos } = rankingList
 
   return (
-    <section className={cn('mt-[52px] w-full', 'mo:pl-[16px]')}>
-      <strong className="text-[26px] font-[700]">투표 랭킹</strong>
-      <div
+    <article className={cn('mt-[52px] w-full', 'mo:pl-[16px]')}>
+      <h1 className="text-[26px] font-[700]">투표 랭킹</h1>
+      <ul
         className={cn(
-          'mt-[22px] flex gap-[33.5px] scrollbar-hide',
+          'mt-[22px] flex gap-[33px] scrollbar-hide',
           'mo:gap-[12px] mo:overflow-x-scroll',
         )}
       >
         {rankingInfos.length > 0 ? (
           rankingInfos.map((item) => (
-            <Link
-              href={`/votes/${item.id}`}
-              key={item.id}
-              className="text-center"
-            >
-              <div className="flex h-[104px] w-[104px] items-center justify-center rounded-full border-[2px] border-[#D9D9D9]">
-                <div className="flex h-[93px] w-[93px] rounded-full border">
-                  <Image
-                    width={46}
-                    height={93}
-                    src={item.item1Image}
-                    alt="vote item1"
-                    className="flex-1 rounded-l-full object-contain"
-                  />
-                  <Image
-                    width={46}
-                    height={93}
-                    src={item.item2Image}
-                    alt="vote item2"
-                    className="flex-1 rounded-r-full object-contain"
-                  />
+            <li key={item.id} className="cursor-pointer text-center">
+              <Link href={`/votes/${item.id}`} className="block h-full w-full">
+                <div className="flex h-[104px] w-[104px] items-center justify-center rounded-full border-[2px] border-[#D9D9D9]">
+                  <figure className="flex h-[93px] w-[93px] rounded-full border">
+                    <VoteImage
+                      src={item.item1Image}
+                      innerClassNames="rounded-l-full"
+                    />
+                    <VoteImage
+                      src={item.item2Image}
+                      innerClassNames="rounded-r-full"
+                    />
+                  </figure>
                 </div>
-              </div>
-              <p className="mt-[11.4px] text-[14.2px] font-[500] text-[#5D5D5D]">
-                {item.participants}명 참여중
-              </p>
-            </Link>
+                <span className="mt-[11.4px] text-[14.2px] font-[500] text-[#5D5D5D]">
+                  {item.participants}명 참여중
+                </span>
+              </Link>
+            </li>
           ))
         ) : (
+          // 투표 랭킹 아이템이 없을 경우
           <div className="h-[104px]" />
         )}
-      </div>
-    </section>
+      </ul>
+    </article>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/_component/VoteImage.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteImage.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import Image from 'next/image'
+
+interface PropsType {
+  src: string
+  innerClassNames: string
+}
+
+export default function VoteImage({ src, innerClassNames }: PropsType) {
+  return (
+    <Image
+      width={46}
+      height={93}
+      src={src}
+      alt="vote image"
+      className={`flex-1 ${innerClassNames}`}
+    />
+  )
+}

--- a/src/app/(route)/(withLayout)/votes/_component/VoteImage.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteImage.tsx
@@ -15,6 +15,7 @@ export default function VoteImage({ src, innerClassNames }: PropsType) {
       src={src}
       alt="vote image"
       className={`flex-1 ${innerClassNames}`}
+      priority
     />
   )
 }

--- a/src/app/(route)/(withLayout)/votes/_component/VoteItem.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteItem.tsx
@@ -5,22 +5,13 @@
  */
 
 import { blurDataURL } from '@/app/_constants/images'
+import { VoteInfo } from '@/app/_types/vote.type'
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 
 interface VoteItemProps {
-  item: {
-    cursorId: string
-    item1Info: { image: string }
-    item2Info: { image: string }
-    voteInfo: {
-      content: string
-      participants: number
-      isVoting: boolean
-      id: number
-    }
-  }
+  item: VoteInfo
   width: number
   height: number
   innerClassNames?: string

--- a/src/app/(route)/(withLayout)/votes/_component/VoteList.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteList.tsx
@@ -16,27 +16,21 @@ export default function VoteList() {
   const { voteList, fetchNextPage, isFetchingNextPage, hasNextPage } =
     useVoteListData(hobby, sortOption.value)
 
+  if (voteList.length === 0) {
+    return <EmptyVoteList />
+  }
+
   return (
     <section className="mo:px-[16px]">
-      {voteList.length === 0 ? (
-        <EmptyVoteList />
-      ) : (
-        <>
-          <div className="mt-[43px] flex justify-end">
-            <SortButtons
-              sortOption={sortOption}
-              setSortOption={setSortOption}
-            />
-          </div>
-          {/** Votes */}
-          <VoteListContent
-            voteList={voteList}
-            fetchNextPage={fetchNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            hasNextPage={hasNextPage}
-          />
-        </>
-      )}
+      <div className="mt-[43px] flex justify-end">
+        <SortButtons sortOption={sortOption} setSortOption={setSortOption} />
+      </div>
+      <VoteListContent
+        voteList={voteList}
+        fetchNextPage={fetchNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+      />
     </section>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/_component/VoteList.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteList.tsx
@@ -1,15 +1,12 @@
 'use client'
 
-import InfiniteScrollTrigger from '@/app/_components/infiniteScrollTrigger'
 import { useVoteListData } from '@/app/_hook/api/votes/queries/useVoteListData'
 import useGetSearchParam from '@/app/_hook/common/useGetSearchParams'
-import { cn } from '@/app/_utils/twMerge'
 import { useState } from 'react'
 import { SortOption } from '../_constants'
 import EmptyVoteList from './EmptyVoteList'
 import SortButtons from './SortButtons'
-import VoteItem from './VoteItem'
-import VoteItemSkeleton from './VoteItemSkeleton'
+import VoteListContent from './VoteListContent'
 
 export default function VoteList() {
   const hobby = useGetSearchParam('category') || '농구'
@@ -32,33 +29,12 @@ export default function VoteList() {
             />
           </div>
           {/** Votes */}
-          <article className="mt-[43px] w-full">
-            <ul
-              className={cn(
-                'grid grid-cols-2 gap-[20px]',
-                'mo:grid-cols-1 mo:gap-[16px]',
-              )}
-            >
-              {voteList.map((item) => (
-                <li
-                  key={item.cursorId}
-                  className={cn('h-[408px] w-[387px]', 'mo:w-full')}
-                >
-                  <VoteItem item={item} width={170} height={208} />
-                </li>
-              ))}
-            </ul>
-            {/** More Item Request */}
-            <div className="flex justify-center gap-[20px] pb-[85px] pt-[32px]">
-              <InfiniteScrollTrigger
-                isFetchingNextPage={isFetchingNextPage}
-                hasNextPage={hasNextPage}
-                fetchNextPage={fetchNextPage}
-              >
-                <VoteItemSkeleton />
-              </InfiniteScrollTrigger>
-            </div>
-          </article>
+          <VoteListContent
+            voteList={voteList}
+            fetchNextPage={fetchNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            hasNextPage={hasNextPage}
+          />
         </>
       )}
     </section>

--- a/src/app/(route)/(withLayout)/votes/_component/VoteListContent.tsx
+++ b/src/app/(route)/(withLayout)/votes/_component/VoteListContent.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import InfiniteScrollTrigger from '@/app/_components/infiniteScrollTrigger'
+import { VoteInfo } from '@/app/_types/vote.type'
+import { cn } from '@/app/_utils/twMerge'
+import VoteItem from './VoteItem'
+import VoteItemSkeleton from './VoteItemSkeleton'
+
+interface VoteListContentProps {
+  voteList: VoteInfo[]
+  fetchNextPage: () => void
+  isFetchingNextPage: boolean
+  hasNextPage: boolean
+}
+
+export default function VoteListContent({
+  voteList,
+  fetchNextPage,
+  isFetchingNextPage,
+  hasNextPage,
+}: VoteListContentProps) {
+  return (
+    <article className="mt-[43px] w-full">
+      <ul
+        className={cn(
+          'grid grid-cols-2 gap-[20px]',
+          'mo:grid-cols-1 mo:gap-[16px]',
+        )}
+      >
+        {voteList.map((item) => (
+          <li
+            key={item.cursorId}
+            className={cn('h-[408px] w-[387px]', 'mo:w-full')}
+          >
+            <VoteItem item={item} width={170} height={208} />
+          </li>
+        ))}
+      </ul>
+      {/** More Item Request */}
+      <div className="flex justify-center gap-[20px] pb-[85px] pt-[32px]">
+        <InfiniteScrollTrigger
+          isFetchingNextPage={isFetchingNextPage}
+          hasNextPage={hasNextPage}
+          fetchNextPage={fetchNextPage}
+        >
+          <VoteItemSkeleton />
+        </InfiniteScrollTrigger>
+      </div>
+    </article>
+  )
+}

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import useAddVote from '@/app/_hook/api/votes/mutations/useAddVote'
+import { useFolderList } from '@/app/_hook/api/votes/queries/useFolderList'
 import { SelectedItemType, VoteInfoType } from '@/app/_types/addVote.type'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { useRouter } from 'next/navigation'
@@ -10,6 +11,9 @@ import VoteModal from './VoteModal'
 
 export default function AddVotePage() {
   const router = useRouter()
+
+  /** 페이지 로드 시 폴더 리스트 데이터 캐싱 */
+  useFolderList('folder')
 
   const [showVoteModal, setShowVoteModal] = useState(false)
   const [itemType, setItemType] = useState<string | null>(null)

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
@@ -1,22 +1,25 @@
 'use client'
 
+import { selectedItemState } from '@/app/_atoms/selectedItemState'
 import useAddVote from '@/app/_hook/api/votes/mutations/useAddVote'
 import { useFolderList } from '@/app/_hook/api/votes/queries/useFolderList'
-import { SelectedItemType, VoteInfoType } from '@/app/_types/addVote.type'
+import { useModals } from '@/app/_hook/common/useModal'
+import { VoteInfoType } from '@/app/_types/addVote.type'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { useRouter } from 'next/navigation'
 import { ChangeEvent, useCallback, useState } from 'react'
+import { useRecoilState, useResetRecoilState } from 'recoil'
 import VoteForm from './VoteForm'
 import VoteModal from './VoteModal'
 
 export default function AddVotePage() {
   const router = useRouter()
+  const { open } = useModals()
 
-  /** 페이지 로드 시 폴더 리스트 데이터 캐싱 */
+  const { mutateAsync: addVote } = useAddVote()
+  /** 찜 폴더 리스트 캐싱 */
   useFolderList('folder')
 
-  const [showVoteModal, setShowVoteModal] = useState(false)
-  const [itemType, setItemType] = useState<string | null>(null)
   const [voteInfo, setVoteInfo] = useState<VoteInfoType>({
     hobby: '',
     maximumParticipants: 100,
@@ -25,41 +28,28 @@ export default function AddVotePage() {
     item2Id: null,
   })
 
-  /**
-   * itemImageUrl1,2 - Selected Item Image URL
-   * itemTitle1,2 - Selected Item Title
-   */
-
-  const [selectedItem, setSelectedItem] = useState<SelectedItemType>({
-    imageUrl1: null,
-    imageUrl2: null,
-    title1: '',
-    title2: '',
-  })
-
-  const { mutateAsync: addVote } = useAddVote()
+  const [selectedItem, setSelectedItem] = useRecoilState(selectedItemState)
+  const resetSelectedItem = useResetRecoilState(selectedItemState)
 
   const handleChange = (
     e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => {
     const { name, value } = e.target
-
     setVoteInfo((prevState) => ({
       ...prevState,
       [name]: value,
     }))
   }
 
-  const handleOpenModal = (type: 'item1' | 'item2') => {
-    setItemType(type)
-    setShowVoteModal(true)
-  }
-
+  /** 찜한 아이템 선택 */
   const handleSelectItem = useCallback(
-    (selectItem: CurrentFavoriteItemMetadata) => {
+    (
+      selectItem: CurrentFavoriteItemMetadata,
+      modalItemType: 'item1' | 'item2',
+    ) => {
       const { itemId, imageUrl, originalName } = selectItem
 
-      if (itemType === 'item1') {
+      if (modalItemType === 'item1') {
         setVoteInfo((prevState) => ({
           ...prevState,
           item1Id: itemId,
@@ -69,7 +59,7 @@ export default function AddVotePage() {
           imageUrl1: imageUrl,
           title1: originalName,
         }))
-      } else if (itemType === 'item2') {
+      } else if (modalItemType === 'item2') {
         setVoteInfo((prevState) => ({
           ...prevState,
           item2Id: itemId,
@@ -81,35 +71,35 @@ export default function AddVotePage() {
         }))
       }
     },
-    [itemType],
+    [setVoteInfo, setSelectedItem],
   )
+
+  const handleOpenModal = (type: 'item1' | 'item2') => {
+    open(VoteModal, {
+      onSelectItem: (item: CurrentFavoriteItemMetadata) =>
+        handleSelectItem(item, type),
+      itemType: type,
+    })
+  }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-
     const status = await addVote(voteInfo)
 
     if (status === 200) {
+      resetSelectedItem()
       router.push('/votes')
     }
   }
 
   return (
-    <>
-      <VoteForm
-        handleChange={handleChange}
-        handleOpenModal={handleOpenModal}
-        handleSubmit={handleSubmit}
-        voteInfo={voteInfo}
-        setVoteInfo={setVoteInfo}
-        selectedItem={selectedItem}
-      />
-      {showVoteModal && (
-        <VoteModal
-          setShowVoteModal={setShowVoteModal}
-          selectItem={handleSelectItem}
-        />
-      )}
-    </>
+    <VoteForm
+      handleChange={handleChange}
+      handleOpenModal={handleOpenModal}
+      handleSubmit={handleSubmit}
+      voteInfo={voteInfo}
+      setVoteInfo={setVoteInfo}
+      selectedItem={selectedItem}
+    />
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/AddVotePage.tsx
@@ -28,7 +28,8 @@ export default function AddVotePage() {
     item2Id: null,
   })
 
-  const [selectedItem, setSelectedItem] = useRecoilState(selectedItemState)
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const [_, setSelectedItem] = useRecoilState(selectedItemState)
   const resetSelectedItem = useResetRecoilState(selectedItemState)
 
   const handleChange = (
@@ -99,7 +100,6 @@ export default function AddVotePage() {
       handleSubmit={handleSubmit}
       voteInfo={voteInfo}
       setVoteInfo={setVoteInfo}
-      selectedItem={selectedItem}
     />
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { currentSelectedItemState } from '@/app/_atoms/currentSelectedItemState'
 import { useFavoritesList } from '@/app/_hook/api/votes/queries/useFavoritesList'
 import {
-  CurrentFavoriteItemMetadata,
   FavoriteItemMetadata,
   MetadataType,
   SaveItemType,
@@ -10,20 +10,21 @@ import {
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 import { useCallback } from 'react'
+import { useRecoilState } from 'recoil'
 import { truncateString } from '../../_utils/truncateString'
 
 interface PropsType {
   folderId: number | null
-  currentSelectedItem: CurrentFavoriteItemMetadata | null
-  setCurrentSelectedItem: React.Dispatch<
-    React.SetStateAction<CurrentFavoriteItemMetadata | null>
-  >
 }
 
 export default function FavoriteList(props: PropsType) {
-  const { folderId, currentSelectedItem, setCurrentSelectedItem } = props
+  const { folderId } = props
 
   const { itemList } = useFavoritesList('item', folderId)
+
+  const [currentSelectedItem, setCurrentSelectedItem] = useRecoilState(
+    currentSelectedItemState,
+  )
 
   const handleSelectItem = useCallback(
     (favoriteItemMetadata: FavoriteItemMetadata, originalName: string) => {

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
@@ -71,8 +71,10 @@ export default function FavoriteList(props: PropsType) {
                 <div className="absolute bottom-0 left-0 right-0 top-0 bg-[#6F6F6F] opacity-80" />
               )}
             </div>
-            <div className="h-[70px] text-[10px] font-[500]">
-              <span>{truncateString(originalName, 26)}</span>
+            <div className="text-[10px] font-[500]">
+              <span className="block pb-[4px]">
+                {truncateString(originalName, 26)}
+              </span>
               <strong className="font-[700]">
                 {favoriteItemMetadata.price.toLocaleString()}원
               </strong>

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/FavoriteItemList.tsx
@@ -71,7 +71,7 @@ export default function FavoriteList(props: PropsType) {
               )}
             </div>
             <div className="h-[70px] text-[10px] font-[500]">
-              <p>{truncateString(originalName, 26)}</p>
+              <span>{truncateString(originalName, 26)}</span>
               <strong className="font-[700]">
                 {favoriteItemMetadata.price.toLocaleString()}원
               </strong>

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/FolderList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/FolderList.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import Image from 'next/image'
 import { FolderMetadataType, SaveItemType } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
+import Image from 'next/image'
 import { useCallback } from 'react'
 
 interface PropsType {

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/ItemSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/ItemSelector.tsx
@@ -1,15 +1,21 @@
+import { selectedItemState } from '@/app/_atoms/selectedItemState'
 import Image from 'next/image'
+import { useRecoilValue } from 'recoil'
 import { truncateString } from '../../_utils/truncateString'
 
 interface PropsType {
   onOpenModal: (itemType: 'item1' | 'item2') => void
-  itemImageUrl: string
-  itemTitle: string
   itemType: 'item1' | 'item2'
 }
 
 export default function ItemSelector(props: PropsType) {
-  const { onOpenModal, itemImageUrl, itemTitle, itemType } = props
+  const { onOpenModal, itemType } = props
+  const selectedItem = useRecoilValue(selectedItemState)
+  const itemImageUrl =
+    itemType === 'item1' ? selectedItem.imageUrl1 : selectedItem.imageUrl2
+  const itemTitle =
+    itemType === 'item1' ? selectedItem.title1 : selectedItem.title2
+
   return (
     <div className="w-[88px]">
       <button

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/MoItemSelectHeader.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/MoItemSelectHeader.tsx
@@ -23,7 +23,7 @@ export default function MoItemSelectHeader(props: PropsType) {
 
   return (
     <header className={cn('hidden', 'mo:block')}>
-      <div className="flex h-[40px] items-center justify-center bg-red-500">
+      <div className="flex h-[40px] items-center justify-center">
         <div className="h-0 w-[42px] rounded-[6px] border-[3px] bg-[#D2D2D2]" />
       </div>
       <div className="flex h-[42px] items-center justify-center px-[16px] font-[600]">

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import CategorySelector from '@/app/_components/categorySelector'
-import { cn } from '@/app/_utils/twMerge'
 import { SelectedItemType, VoteInfoType } from '@/app/_types/addVote.type'
+import { cn } from '@/app/_utils/twMerge'
 import { ChangeEvent } from 'react'
 import ItemSelector from './ItemSelector'
 
@@ -26,15 +26,18 @@ export default function VoteForm(props: PropsType) {
   } = props
 
   return (
-    <form onSubmit={handleSubmit} className="mo:w-full">
+    <form
+      onSubmit={handleSubmit}
+      className={cn('justify-center, flex flex-col mo:w-full')}
+    >
       <div
         className={cn(
           'mt-[61px] flex gap-[8px] text-[18px] font-[600]',
           'mo:w-full',
         )}
       >
-        <h1>투표 인원을 설정해 주세요</h1>
-        <p className="text-[#A4A4A4]">(선택)</p>
+        <span>투표 인원을 설정해 주세요</span>
+        <span className="text-[#A4A4A4]">(선택)</span>
       </div>
       <input
         name="maximumParticipants"
@@ -45,21 +48,21 @@ export default function VoteForm(props: PropsType) {
         placeholder="숫자만 입력해 주세요."
         onChange={handleChange}
       />
-      <p className="mt-[8px] text-[14px] font-[400] text-[#A4A4A4]">
+      <span className="mt-[8px] text-[14px] font-[400] text-[#A4A4A4]">
         * 투표 인원은 최대 1000명까지 가능합니다.
-      </p>
-      <p className="mt-[4px] text-[14px] font-[400] text-[#A4A4A4]">
+      </span>
+      <span className="mt-[4px] text-[14px] font-[400] text-[#A4A4A4]">
         * 입력하지 않을 시 기본 투표 인원은 100명입니다.
-      </p>
-      <p className="mt-[60px] text-[18px] font-[600]">
+      </span>
+      <span className="mt-[60px] text-[18px] font-[600]">
         투표할 취미를 선택해 주세요.
-      </p>
+      </span>
       <CategorySelector
         setCategory={(hobby) => setVoteInfo({ ...voteInfo, hobby })}
       />
-      <p className="mt-[60px] text-[18px] font-[600]">
+      <span className="mt-[60px] text-[18px] font-[600]">
         투표할 아이템을 두 개 선택해 주세요.
-      </p>
+      </span>
       <div className="mt-[20px] flex h-[160px] gap-[16px] ">
         <ItemSelector
           onOpenModal={handleOpenModal}
@@ -74,9 +77,9 @@ export default function VoteForm(props: PropsType) {
           itemTitle={selectedItem.title2}
         />
       </div>
-      <p className="mb-[20px] mt-[40px] text-[18px] font-[600]">
+      <span className="mb-[20px] mt-[40px] text-[18px] font-[600]">
         투표 내용을 작성해 주세요.
-      </p>
+      </span>
       <textarea
         name="content"
         placeholder="최소 10자 이상 작성해 주세요."

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
@@ -64,18 +64,8 @@ export default function VoteForm(props: PropsType) {
         투표할 아이템을 두 개 선택해 주세요.
       </span>
       <div className="mt-[20px] flex h-[160px] gap-[16px] ">
-        <ItemSelector
-          onOpenModal={handleOpenModal}
-          itemType="item1"
-          itemImageUrl={selectedItem.imageUrl1 || ''}
-          itemTitle={selectedItem.title1}
-        />
-        <ItemSelector
-          onOpenModal={handleOpenModal}
-          itemType="item2"
-          itemImageUrl={selectedItem.imageUrl2 || ''}
-          itemTitle={selectedItem.title2}
-        />
+        <ItemSelector onOpenModal={handleOpenModal} itemType="item1" />
+        <ItemSelector onOpenModal={handleOpenModal} itemType="item2" />
       </div>
       <span className="mb-[20px] mt-[40px] text-[18px] font-[600]">
         투표 내용을 작성해 주세요.

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import CategorySelector from '@/app/_components/categorySelector'
-import { SelectedItemType, VoteInfoType } from '@/app/_types/addVote.type'
+import { VoteInfoType } from '@/app/_types/addVote.type'
 import { cn } from '@/app/_utils/twMerge'
 import { ChangeEvent } from 'react'
 import ItemSelector from './ItemSelector'
@@ -12,18 +12,11 @@ interface PropsType {
   voteInfo: VoteInfoType
   setVoteInfo: (voteInfo: VoteInfoType) => void
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  selectedItem: SelectedItemType
 }
 
 export default function VoteForm(props: PropsType) {
-  const {
-    handleChange,
-    handleOpenModal,
-    voteInfo,
-    setVoteInfo,
-    handleSubmit,
-    selectedItem,
-  } = props
+  const { handleChange, handleOpenModal, voteInfo, setVoteInfo, handleSubmit } =
+    props
 
   return (
     <form

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
@@ -2,30 +2,20 @@
 
 import Loading from '@/app/_components/loading'
 import { useFolderList } from '@/app/_hook/api/votes/queries/useFolderList'
-import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
 import { Suspense, useState } from 'react'
 import FolderList from './FolderList'
 import VoteItemsSelector from './VoteItemsSelector'
 
 interface PropsType {
-  setCurrentSelectedItem: React.Dispatch<
-    React.SetStateAction<CurrentFavoriteItemMetadata | null>
-  >
-  currentSelectedItem: CurrentFavoriteItemMetadata | null
   showMobileItemList: boolean
   setShowMobileItemList: React.Dispatch<React.SetStateAction<boolean>>
   setCurrentFolderName: React.Dispatch<React.SetStateAction<string>>
 }
 
 export default function VoteItemList(props: PropsType) {
-  const {
-    setCurrentSelectedItem,
-    currentSelectedItem,
-    showMobileItemList,
-    setShowMobileItemList,
-    setCurrentFolderName,
-  } = props
+  const { showMobileItemList, setShowMobileItemList, setCurrentFolderName } =
+    props
 
   const [selectedFolder, setSelectedFolder] = useState<{
     folderId: number | null
@@ -65,21 +55,13 @@ export default function VoteItemList(props: PropsType) {
       ) : (
         <div className={cn('hidden w-full', 'mo:block')}>
           <Suspense fallback={<Loading />}>
-            <VoteItemsSelector
-              selectedFolder={selectedFolder}
-              currentSelectedItem={currentSelectedItem}
-              setCurrentSelectedItem={setCurrentSelectedItem}
-            />
+            <VoteItemsSelector selectedFolder={selectedFolder} />
           </Suspense>
         </div>
       )}
       <div className={cn('flex-1 overflow-y-auto pl-[16px]', 'mo:hidden')}>
         <Suspense fallback={<Loading />}>
-          <VoteItemsSelector
-            selectedFolder={selectedFolder}
-            currentSelectedItem={currentSelectedItem}
-            setCurrentSelectedItem={setCurrentSelectedItem}
-          />
+          <VoteItemsSelector selectedFolder={selectedFolder} />
         </Suspense>
       </div>
     </div>

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
@@ -1,12 +1,9 @@
 'use client'
 
-import { fetchFavoriteList } from '@/app/_hook/api/votes/queries/useFavoritesList'
-import {
-  CurrentFavoriteItemMetadata,
-  SaveItemType,
-} from '@/app/_types/saveItem.type'
+import { useFolderList } from '@/app/_hook/api/votes/queries/useFolderList'
+import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import FolderList from './FolderList'
 import VoteItemsSelector from './VoteItemsSelector'
 
@@ -29,20 +26,13 @@ export default function VoteItemList(props: PropsType) {
     setCurrentFolderName,
   } = props
 
-  const [folderInfo, setFolderInfo] = useState<SaveItemType[]>([])
   const [selectedFolder, setSelectedFolder] = useState<{
     folderId: number | null
     itemCount: number | null
   }>({ folderId: null, itemCount: null })
 
-  const fetchFolderList = async () => {
-    const { favoriteInfos } = await fetchFavoriteList({ type: 'folder' })
-    setFolderInfo(favoriteInfos)
-  }
-
-  useEffect(() => {
-    fetchFolderList()
-  }, [showMobileItemList])
+  const { folderList } = useFolderList('folder')
+  const { favoriteInfos } = folderList
 
   return (
     <div
@@ -52,7 +42,7 @@ export default function VoteItemList(props: PropsType) {
       )}
     >
       <FolderList
-        favoriteInfos={folderInfo}
+        favoriteInfos={favoriteInfos}
         selectedFolder={selectedFolder}
         setSelectedFolder={setSelectedFolder}
         setCurrentFolderName={setCurrentFolderName}
@@ -65,7 +55,7 @@ export default function VoteItemList(props: PropsType) {
           }}
         >
           <FolderList
-            favoriteInfos={folderInfo}
+            favoriteInfos={favoriteInfos}
             selectedFolder={selectedFolder}
             setSelectedFolder={setSelectedFolder}
             setCurrentFolderName={setCurrentFolderName}

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemList.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import Loading from '@/app/_components/loading'
 import { useFolderList } from '@/app/_hook/api/votes/queries/useFolderList'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 import FolderList from './FolderList'
 import VoteItemsSelector from './VoteItemsSelector'
 
@@ -63,19 +64,23 @@ export default function VoteItemList(props: PropsType) {
         </div>
       ) : (
         <div className={cn('hidden w-full', 'mo:block')}>
+          <Suspense fallback={<Loading />}>
+            <VoteItemsSelector
+              selectedFolder={selectedFolder}
+              currentSelectedItem={currentSelectedItem}
+              setCurrentSelectedItem={setCurrentSelectedItem}
+            />
+          </Suspense>
+        </div>
+      )}
+      <div className={cn('flex-1 overflow-y-auto pl-[16px]', 'mo:hidden')}>
+        <Suspense fallback={<Loading />}>
           <VoteItemsSelector
             selectedFolder={selectedFolder}
             currentSelectedItem={currentSelectedItem}
             setCurrentSelectedItem={setCurrentSelectedItem}
           />
-        </div>
-      )}
-      <div className={cn('flex-1 overflow-y-auto pl-[16px]', 'mo:hidden')}>
-        <VoteItemsSelector
-          selectedFolder={selectedFolder}
-          currentSelectedItem={currentSelectedItem}
-          setCurrentSelectedItem={setCurrentSelectedItem}
-        />
+        </Suspense>
       </div>
     </div>
   )

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
 import FavoriteList from './FavoriteItemList'
 
@@ -9,14 +8,10 @@ interface PropsType {
     folderId: number | null
     itemCount: number | null
   }
-  currentSelectedItem: CurrentFavoriteItemMetadata | null
-  setCurrentSelectedItem: React.Dispatch<
-    React.SetStateAction<CurrentFavoriteItemMetadata | null>
-  >
 }
 
 export default function VoteItemsSelector(props: PropsType) {
-  const { currentSelectedItem, setCurrentSelectedItem, selectedFolder } = props
+  const { selectedFolder } = props
 
   return (
     <div>
@@ -25,11 +20,7 @@ export default function VoteItemsSelector(props: PropsType) {
           <span className={cn('my-[13px] block text-[12px]', 'mo:hidden')}>
             아이템 {selectedFolder.itemCount}개
           </span>
-          <FavoriteList
-            folderId={selectedFolder.folderId}
-            currentSelectedItem={currentSelectedItem}
-            setCurrentSelectedItem={setCurrentSelectedItem}
-          />
+          <FavoriteList folderId={selectedFolder.folderId} />
         </>
       ) : (
         <div

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -22,9 +22,9 @@ export default function VoteItemsSelector(props: PropsType) {
     <div>
       {selectedFolder.itemCount !== 0 && selectedFolder.folderId ? (
         <>
-          <p className={cn('my-[13px] text-[12px]', 'mo:hidden')}>
+          <span className={cn('my-[13px] text-[12px]', 'mo:hidden')}>
             아이템 {selectedFolder.itemCount}개
-          </p>
+          </span>
           <FavoriteList
             folderId={selectedFolder.folderId}
             currentSelectedItem={currentSelectedItem}
@@ -41,9 +41,9 @@ export default function VoteItemsSelector(props: PropsType) {
           <strong className="mb-[12px] text-[20px] font-[600]">
             찜한 아이템이 없어요
           </strong>
-          <p className="text-[14px] font-[500]">
+          <span className="text-[14px] font-[500]">
             마음에 드는 아이템을 담아보세요
-          </p>
+          </span>
         </div>
       )}
     </div>

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -10,33 +10,31 @@ interface PropsType {
   }
 }
 
-export default function VoteItemsSelector(props: PropsType) {
-  const { selectedFolder } = props
+export default function VoteItemsSelector({ selectedFolder }: PropsType) {
+  if (!selectedFolder.itemCount && !selectedFolder.folderId) {
+    return (
+      <div
+        className={cn(
+          'flex h-full flex-col items-center justify-center pt-[160px]',
+          'mo:pt-[250px]',
+        )}
+      >
+        <strong className="mb-[12px] text-[20px] font-[600]">
+          찜한 아이템이 없어요
+        </strong>
+        <span className="text-[14px] font-[500]">
+          마음에 드는 아이템을 담아보세요
+        </span>
+      </div>
+    )
+  }
 
   return (
-    <div>
-      {selectedFolder.itemCount !== 0 && selectedFolder.folderId ? (
-        <>
-          <span className={cn('my-[13px] block text-[12px]', 'mo:hidden')}>
-            아이템 {selectedFolder.itemCount}개
-          </span>
-          <FavoriteList folderId={selectedFolder.folderId} />
-        </>
-      ) : (
-        <div
-          className={cn(
-            'flex h-full flex-col items-center justify-center pt-[160px]',
-            'mo:pt-[250px]',
-          )}
-        >
-          <strong className="mb-[12px] text-[20px] font-[600]">
-            찜한 아이템이 없어요
-          </strong>
-          <span className="text-[14px] font-[500]">
-            마음에 드는 아이템을 담아보세요
-          </span>
-        </div>
-      )}
-    </div>
+    <>
+      <span className={cn('my-[13px] block text-[12px]', 'mo:hidden')}>
+        아이템 {selectedFolder.itemCount}개
+      </span>
+      <FavoriteList folderId={selectedFolder.folderId} />
+    </>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -2,9 +2,6 @@
 
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
-import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
-import ErrorFallback from '@/app/_components/errorFallback'
-import Loading from '@/app/_components/loading'
 import FavoriteList from './FavoriteItemList'
 
 interface PropsType {
@@ -28,16 +25,11 @@ export default function VoteItemsSelector(props: PropsType) {
           <p className={cn('my-[13px] text-[12px]', 'mo:hidden')}>
             아이템 {selectedFolder.itemCount}개
           </p>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<Loading />}
-          >
-            <FavoriteList
-              folderId={selectedFolder.folderId}
-              currentSelectedItem={currentSelectedItem}
-              setCurrentSelectedItem={setCurrentSelectedItem}
-            />
-          </ErrorHandlingWrapper>
+          <FavoriteList
+            folderId={selectedFolder.folderId}
+            currentSelectedItem={currentSelectedItem}
+            setCurrentSelectedItem={setCurrentSelectedItem}
+          />
         </>
       ) : (
         <div

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -11,7 +11,10 @@ interface PropsType {
 }
 
 export default function VoteItemsSelector({ selectedFolder }: PropsType) {
-  if (!selectedFolder.itemCount && !selectedFolder.folderId) {
+  if (
+    (!selectedFolder.itemCount && !selectedFolder.folderId) ||
+    selectedFolder.itemCount === 0
+  ) {
     return (
       <div
         className={cn(

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteItemsSelector.tsx
@@ -22,7 +22,7 @@ export default function VoteItemsSelector(props: PropsType) {
     <div>
       {selectedFolder.itemCount !== 0 && selectedFolder.folderId ? (
         <>
-          <span className={cn('my-[13px] text-[12px]', 'mo:hidden')}>
+          <span className={cn('my-[13px] block text-[12px]', 'mo:hidden')}>
             아이템 {selectedFolder.itemCount}개
           </span>
           <FavoriteList

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import ErrorFallback from '@/app/_components/errorFallback'
+import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
+import Loading from '@/app/_components/loading'
 import Modal from '@/app/_components/modal'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
@@ -57,13 +60,18 @@ export default function VoteModal(props: PropsType) {
             handleSelectItem={handleSelectItem}
           />
           <article className={cn('px-[46px]', 'mo:px-0')}>
-            <VoteItemList
-              currentSelectedItem={currentSelectedItem}
-              setCurrentSelectedItem={setCurrentSelectedItem}
-              showMobileItemList={showMobileItemList}
-              setShowMobileItemList={setShowMobileItemList}
-              setCurrentFolderName={setCurrentFolderName}
-            />
+            <ErrorHandlingWrapper
+              fallbackComponent={ErrorFallback}
+              suspenseFallback={<Loading />}
+            >
+              <VoteItemList
+                currentSelectedItem={currentSelectedItem}
+                setCurrentSelectedItem={setCurrentSelectedItem}
+                showMobileItemList={showMobileItemList}
+                setShowMobileItemList={setShowMobileItemList}
+                setCurrentFolderName={setCurrentFolderName}
+              />
+            </ErrorHandlingWrapper>
             <div
               className={cn(
                 'mt-[43px] flex items-center justify-between',

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -4,6 +4,7 @@ import ErrorFallback from '@/app/_components/errorFallback'
 import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
 import Loading from '@/app/_components/loading'
 import Modal from '@/app/_components/modal'
+import { useModals } from '@/app/_hook/common/useModal'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
@@ -15,16 +16,16 @@ import VoteItemList from './VoteItemList'
 import VoteModalHeader from './VoteModalHeader'
 
 interface PropsType {
-  setShowVoteModal: React.Dispatch<React.SetStateAction<boolean>>
-  selectItem: (selectItem: CurrentFavoriteItemMetadata) => void
+  onSelectItem: (
+    selectItem: CurrentFavoriteItemMetadata,
+    modalItemType: 'item1' | 'item2',
+  ) => void
+  itemType: 'item1' | 'item2'
 }
 
-export default function VoteModal(props: PropsType) {
-  const { setShowVoteModal, selectItem: onSelectItem } = props
-
+export default function VoteModal({ onSelectItem, itemType }: PropsType) {
   const router = useRouter()
-
-  /** Select item (not confirmed) */
+  const { close } = useModals()
   const [currentSelectedItem, setCurrentSelectedItem] =
     useState<CurrentFavoriteItemMetadata | null>(null)
   const [showMobileItemList, setShowMobileItemList] = useState(false)
@@ -32,8 +33,8 @@ export default function VoteModal(props: PropsType) {
 
   const handleSelectItem = () => {
     if (validateSelectedItem(currentSelectedItem)) {
-      onSelectItem(currentSelectedItem as CurrentFavoriteItemMetadata)
-      setShowVoteModal(false)
+      onSelectItem(currentSelectedItem as CurrentFavoriteItemMetadata, itemType)
+      close()
     }
   }
 
@@ -41,7 +42,7 @@ export default function VoteModal(props: PropsType) {
     <div
       className="h-full w-full"
       onClick={() => {
-        setShowVoteModal(false)
+        close()
       }}
     >
       <Modal
@@ -50,7 +51,7 @@ export default function VoteModal(props: PropsType) {
       >
         <div className={cn('h-[592px] w-[852px]', 'mo:w-full')}>
           {/** PC Modal Header */}
-          <VoteModalHeader setShowVoteModal={setShowVoteModal} />
+          <VoteModalHeader />
           {/** Mobile Modal Header */}
           <MoItemSelectHeader
             setShowMobileItemList={setShowMobileItemList}

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -33,14 +33,14 @@ export default function VoteModal({ onSelectItem, itemType }: PropsType) {
   const [currentSelectedItem, setCurrentSelectedItem] = useRecoilState(
     currentSelectedItemState,
   )
-  // const [currentSelectedItem, setCurrentSelectedItem] =
-  //   useState<CurrentFavoriteItemMetadata | null>(null)
+
   const [showMobileItemList, setShowMobileItemList] = useState(false)
   const [currentFolderName, setCurrentFolderName] = useState('찜목록')
 
   const handleSelectItem = () => {
     if (validateSelectedItem(currentSelectedItem)) {
       onSelectItem(currentSelectedItem as CurrentFavoriteItemMetadata, itemType)
+      setCurrentSelectedItem(null)
       close()
     }
   }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import Modal from '@/app/_components/modal'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
-import VoteItemList from './VoteItemList'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { validateSelectedItem } from '../_utils/validation'
 import MoItemSelectHeader from './MoItemSelectHeader'
+import VoteItemList from './VoteItemList'
 import VoteModalHeader from './VoteModalHeader'
 
 interface PropsType {
@@ -35,8 +35,8 @@ export default function VoteModal(props: PropsType) {
   }
 
   return (
-    <dialog
-      className="block h-full w-full"
+    <div
+      className="h-full w-full"
       onClick={() => {
         setShowVoteModal(false)
       }}
@@ -64,7 +64,6 @@ export default function VoteModal(props: PropsType) {
               setShowMobileItemList={setShowMobileItemList}
               setCurrentFolderName={setCurrentFolderName}
             />
-            {/** Go to ItemList */}
             <div
               className={cn(
                 'mt-[43px] flex items-center justify-between',
@@ -87,9 +86,9 @@ export default function VoteModal(props: PropsType) {
                 </span>
               </button>
               <div className="absolute bottom-[60px] left-[45px] flex flex-col items-center">
-                <div className=" h-[27px] w-[152px] rounded-[4px] bg-[#000] px-[17px] py-[7px] text-[10px] font-[600] text-[#fff]">
+                <span className=" h-[27px] w-[152px] rounded-[4px] bg-[#000] px-[17px] py-[7px] text-[10px] font-[600] text-[#fff]">
                   취미에 맞는 아이템이 없다면?
-                </div>
+                </span>
                 <div className="h-0 w-0 border-l-[7px] border-r-[7px] border-t-[7px] border-l-transparent border-r-transparent border-t-black" />
               </div>
               <button
@@ -103,6 +102,6 @@ export default function VoteModal(props: PropsType) {
           </article>
         </div>
       </Modal>
-    </dialog>
+    </div>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -5,6 +5,7 @@ import ErrorFallback from '@/app/_components/errorFallback'
 import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
 import Loading from '@/app/_components/loading'
 import Modal from '@/app/_components/modal'
+import Portal from '@/app/_components/potal'
 import { useModals } from '@/app/_hook/common/useModal'
 import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
 import { cn } from '@/app/_utils/twMerge'
@@ -46,76 +47,78 @@ export default function VoteModal({ onSelectItem, itemType }: PropsType) {
   }
 
   return (
-    <div
-      className="h-full w-full"
-      onClick={() => {
-        close()
-      }}
-    >
-      <Modal
-        isScrollActive={false}
-        innerClassNames="mo:bottom-0 mo:top-[15%] mo:w-full mo:max-w-full mo:-translate-y-0"
+    <Portal title="add-vote-modal">
+      <div
+        className="h-full w-full"
+        onClick={() => {
+          close()
+        }}
       >
-        <div className={cn('h-[592px] w-[852px]', 'mo:w-full')}>
-          {/** PC Modal Header */}
-          <VoteModalHeader />
-          {/** Mobile Modal Header */}
-          <MoItemSelectHeader
-            setShowMobileItemList={setShowMobileItemList}
-            setCurrentFolderName={setCurrentFolderName}
-            currentSelectedItem={currentSelectedItem}
-            currentFolderName={currentFolderName}
-            handleSelectItem={handleSelectItem}
-          />
-          <article className={cn('px-[46px]', 'mo:px-0')}>
-            <ErrorHandlingWrapper
-              fallbackComponent={ErrorFallback}
-              suspenseFallback={<Loading />}
-            >
-              <VoteItemList
-                showMobileItemList={showMobileItemList}
-                setShowMobileItemList={setShowMobileItemList}
-                setCurrentFolderName={setCurrentFolderName}
-              />
-            </ErrorHandlingWrapper>
-            <div
-              className={cn(
-                'mt-[43px] flex items-center justify-between',
-                'mo:hidden',
-              )}
-            >
-              <button
-                type="button"
-                className="flex items-center"
-                onClick={() => router.push('/items')}
+        <Modal
+          isScrollActive={false}
+          innerClassNames="mo:bottom-0 mo:top-[15%] mo:w-full mo:max-w-full mo:-translate-y-0"
+        >
+          <div className={cn('h-[592px] w-[852px]', 'mo:w-full')}>
+            {/** PC Modal Header */}
+            <VoteModalHeader />
+            {/** Mobile Modal Header */}
+            <MoItemSelectHeader
+              setShowMobileItemList={setShowMobileItemList}
+              setCurrentFolderName={setCurrentFolderName}
+              currentSelectedItem={currentSelectedItem}
+              currentFolderName={currentFolderName}
+              handleSelectItem={handleSelectItem}
+            />
+            <article className={cn('px-[46px]', 'mo:px-0')}>
+              <ErrorHandlingWrapper
+                fallbackComponent={ErrorFallback}
+                suspenseFallback={<Loading />}
               >
-                <Image
-                  width={15}
-                  height={15}
-                  src="/image/icon/icon-plus.svg"
-                  alt="plus item"
+                <VoteItemList
+                  showMobileItemList={showMobileItemList}
+                  setShowMobileItemList={setShowMobileItemList}
+                  setCurrentFolderName={setCurrentFolderName}
                 />
-                <span className="relative ml-[6px] font-[600]">
-                  아이템 담으러 가기
-                </span>
-              </button>
-              <div className="absolute bottom-[60px] left-[45px] flex flex-col items-center">
-                <span className=" h-[27px] w-[152px] rounded-[4px] bg-[#000] px-[17px] py-[7px] text-[10px] font-[600] text-[#fff]">
-                  취미에 맞는 아이템이 없다면?
-                </span>
-                <div className="h-0 w-0 border-l-[7px] border-r-[7px] border-t-[7px] border-l-transparent border-r-transparent border-t-black" />
-              </div>
-              <button
-                type="button"
-                className="h-[40px] w-[110px] rounded-[100px] bg-black px-[27px] text-center font-[600] text-[#fff]"
-                onClick={handleSelectItem}
+              </ErrorHandlingWrapper>
+              <div
+                className={cn(
+                  'mt-[43px] flex items-center justify-between',
+                  'mo:hidden',
+                )}
               >
-                선택완료
-              </button>
-            </div>
-          </article>
-        </div>
-      </Modal>
-    </div>
+                <button
+                  type="button"
+                  className="flex items-center"
+                  onClick={() => router.push('/items')}
+                >
+                  <Image
+                    width={15}
+                    height={15}
+                    src="/image/icon/icon-plus.svg"
+                    alt="plus item"
+                  />
+                  <span className="relative ml-[6px] font-[600]">
+                    아이템 담으러 가기
+                  </span>
+                </button>
+                <div className="absolute bottom-[60px] left-[45px] flex flex-col items-center">
+                  <span className=" h-[27px] w-[152px] rounded-[4px] bg-[#000] px-[17px] py-[7px] text-[10px] font-[600] text-[#fff]">
+                    취미에 맞는 아이템이 없다면?
+                  </span>
+                  <div className="h-0 w-0 border-l-[7px] border-r-[7px] border-t-[7px] border-l-transparent border-r-transparent border-t-black" />
+                </div>
+                <button
+                  type="button"
+                  className="h-[40px] w-[110px] rounded-[100px] bg-black px-[27px] text-center font-[600] text-[#fff]"
+                  onClick={handleSelectItem}
+                >
+                  선택완료
+                </button>
+              </div>
+            </article>
+          </div>
+        </Modal>
+      </div>
+    </Portal>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { currentSelectedItemState } from '@/app/_atoms/currentSelectedItemState'
 import ErrorFallback from '@/app/_components/errorFallback'
 import ErrorHandlingWrapper from '@/app/_components/errorHandlingWrapper'
 import Loading from '@/app/_components/loading'
@@ -10,6 +11,7 @@ import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { useRecoilState } from 'recoil'
 import { validateSelectedItem } from '../_utils/validation'
 import MoItemSelectHeader from './MoItemSelectHeader'
 import VoteItemList from './VoteItemList'
@@ -25,9 +27,14 @@ interface PropsType {
 
 export default function VoteModal({ onSelectItem, itemType }: PropsType) {
   const router = useRouter()
+
   const { close } = useModals()
-  const [currentSelectedItem, setCurrentSelectedItem] =
-    useState<CurrentFavoriteItemMetadata | null>(null)
+
+  const [currentSelectedItem, setCurrentSelectedItem] = useRecoilState(
+    currentSelectedItemState,
+  )
+  // const [currentSelectedItem, setCurrentSelectedItem] =
+  //   useState<CurrentFavoriteItemMetadata | null>(null)
   const [showMobileItemList, setShowMobileItemList] = useState(false)
   const [currentFolderName, setCurrentFolderName] = useState('찜목록')
 
@@ -66,8 +73,6 @@ export default function VoteModal({ onSelectItem, itemType }: PropsType) {
               suspenseFallback={<Loading />}
             >
               <VoteItemList
-                currentSelectedItem={currentSelectedItem}
-                setCurrentSelectedItem={setCurrentSelectedItem}
                 showMobileItemList={showMobileItemList}
                 setShowMobileItemList={setShowMobileItemList}
                 setCurrentFolderName={setCurrentFolderName}

--- a/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModalHeader.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/_component/VoteModalHeader.tsx
@@ -1,13 +1,12 @@
 'use client'
 
+import { useModals } from '@/app/_hook/common/useModal'
 import { cn } from '@/app/_utils/twMerge'
 import Image from 'next/image'
 
-export default function VoteModalHeader({
-  setShowVoteModal,
-}: {
-  setShowVoteModal: React.Dispatch<React.SetStateAction<boolean>>
-}) {
+export default function VoteModalHeader() {
+  const { close } = useModals()
+
   return (
     <header
       className={cn(
@@ -20,7 +19,7 @@ export default function VoteModalHeader({
         type="button"
         aria-label="close"
         onClick={() => {
-          setShowVoteModal(false)
+          close()
         }}
       >
         <Image

--- a/src/app/(route)/(withLayout)/votes/add-vote/layout.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/layout.tsx
@@ -6,9 +6,9 @@ export default function AddVoteLayout({
   children: React.ReactNode
 }) {
   return (
-    <main className="bg-[#F7F7F7]">
+    <section className="bg-[#F7F7F7]">
       <MoAddVoteHeader />
       {children}
-    </main>
+    </section>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
@@ -18,7 +18,7 @@ export default function page() {
       >
         투표 생성
       </h1>
-      <Suspense fallback={<div>loading</div>}>
+      <Suspense>
         <AddVotePage />
       </Suspense>
     </main>

--- a/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/app/_utils/twMerge'
+import { Suspense } from 'react'
 import AddVotePage from './_component/AddVotePage'
 
 export default function page() {
@@ -17,7 +18,9 @@ export default function page() {
       >
         투표 생성
       </h1>
-      <AddVotePage />
+      <Suspense fallback={<div>loading</div>}>
+        <AddVotePage />
+      </Suspense>
     </main>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
+++ b/src/app/(route)/(withLayout)/votes/add-vote/page.tsx
@@ -3,7 +3,7 @@ import AddVotePage from './_component/AddVotePage'
 
 export default function page() {
   return (
-    <section
+    <main
       className={cn(
         'mx-auto w-[780px] bg-white px-[30px]',
         ' mo:w-full mo:px-[16px]',
@@ -18,6 +18,6 @@ export default function page() {
         투표 생성
       </h1>
       <AddVotePage />
-    </section>
+    </main>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/layout.tsx
+++ b/src/app/(route)/(withLayout)/votes/layout.tsx
@@ -9,11 +9,11 @@ export default function DetailItemLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
+    <section>
       <MoVoteHeader />
       <RQProvider>{children}</RQProvider>
       <MoAddButton path="votes/add-vote" />
       <MoNavbar />
-    </>
+    </section>
   )
 }

--- a/src/app/(route)/(withLayout)/votes/layout.tsx
+++ b/src/app/(route)/(withLayout)/votes/layout.tsx
@@ -1,4 +1,3 @@
-import RQProvider from '@/app/_components/RQProvider'
 import MoAddButton from '@/app/_components/layout/mobile/MoAddButton'
 import MoNavbar from '@/app/_components/layout/mobile/MoNavbar'
 import MoVoteHeader from './_component/MoVoteHeader'
@@ -11,7 +10,7 @@ export default function DetailItemLayout({
   return (
     <section>
       <MoVoteHeader />
-      <RQProvider>{children}</RQProvider>
+      {children}
       <MoAddButton path="votes/add-vote" />
       <MoNavbar />
     </section>

--- a/src/app/(route)/(withLayout)/votes/page.tsx
+++ b/src/app/(route)/(withLayout)/votes/page.tsx
@@ -10,10 +10,10 @@ import VoteList from './_component/VoteList'
 export default function page() {
   return (
     <main className={cn('mx-auto w-[794px]', 'mo:w-full')}>
-      <section className={cn('mt-[52px] flex justify-between', 'mo:pt-[16px]')}>
+      <nav className={cn('mt-[52px] flex justify-between', 'mo:pt-[16px]')}>
         <CategoryPicker path="/votes" />
         <CreateVoteButton />
-      </section>
+      </nav>
       <ErrorHandlingWrapper
         fallbackComponent={ErrorFallback}
         suspenseFallback={<Loading />}

--- a/src/app/_atoms/currentSelectedItemState.ts
+++ b/src/app/_atoms/currentSelectedItemState.ts
@@ -1,0 +1,10 @@
+/** (미확정) 아이템 선택 */
+
+import { CurrentFavoriteItemMetadata } from '@/app/_types/saveItem.type'
+import { atom } from 'recoil'
+
+export const currentSelectedItemState =
+  atom<CurrentFavoriteItemMetadata | null>({
+    key: 'currentSelectedItemState',
+    default: null,
+  })

--- a/src/app/_atoms/modalState.ts
+++ b/src/app/_atoms/modalState.ts
@@ -1,0 +1,13 @@
+/** 모달 on/off 관리 */
+
+import { atom } from 'recoil'
+
+export interface ModalComponentProps<P = Record<string, unknown>> {
+  Component: React.FC<P>
+  props?: P
+}
+
+export const modalsState = atom<ModalComponentProps[]>({
+  key: 'modalsState',
+  default: [],
+})

--- a/src/app/_atoms/selectedItemState.ts
+++ b/src/app/_atoms/selectedItemState.ts
@@ -1,0 +1,14 @@
+/** 아이템 선택 확정 시 투표 이미지, 제목 설정 */
+
+import { SelectedItemType } from '@/app/_types/addVote.type'
+import { atom } from 'recoil'
+
+export const selectedItemState = atom<SelectedItemType>({
+  key: 'selectedItemState',
+  default: {
+    imageUrl1: null,
+    imageUrl2: null,
+    title1: '',
+    title2: '',
+  },
+})

--- a/src/app/_components/categoryPicker/CategoryPicker.tsx
+++ b/src/app/_components/categoryPicker/CategoryPicker.tsx
@@ -1,20 +1,22 @@
 'use client'
 
+import { CategoryOption } from '@/app/_constants'
+import useGetSearchParam from '@/app/_hook/common/useGetSearchParams'
 import { cn } from '@/app/_utils/twMerge'
 import Link from 'next/link'
-import useGetSearchParam from '@/app/_hook/common/useGetSearchParams'
-import { CategoryOption } from '@/app/_constants'
 import { defaultCategory } from '../../_utils/defaultCategory'
+
+interface PropsType {
+  path: string
+  innerClassNames?: string
+  isMenu?: boolean
+}
 
 export default function CategoryPicker({
   path,
   innerClassNames,
   isMenu,
-}: {
-  path: string
-  innerClassNames?: string
-  isMenu?: boolean
-}) {
+}: PropsType) {
   const title = useGetSearchParam('title') || '스포츠'
   const category = useGetSearchParam('category') || '농구'
   const menu = useGetSearchParam('menu') || 'MY투표'
@@ -24,7 +26,7 @@ export default function CategoryPicker({
   })
 
   return (
-    <div className="w-full">
+    <div>
       <ul
         className={cn(
           `flex gap-[15px] text-[20px] font-[700] ${innerClassNames}`,
@@ -32,25 +34,26 @@ export default function CategoryPicker({
         )}
       >
         {CategoryOption.map((item) => (
-          <Link
-            href={`${!isMenu ? '?' : `${path}${menu}&`}title=${item.title}&category=${defaultCategory(
-              item.title,
-            )}`}
-            key={item.title}
-          >
-            <li
-              className={cn(
-                'cursor-pointer rounded-[83.333px] px-[16px] py-[8px] text-[#fff]',
-                {
-                  'bg-black text-white mo:rounded-none mo:border-2 mo:border-x-0 mo:border-t-0 mo:border-black mo:bg-white mo:text-black':
-                    title === item.title,
-                  'bg-white text-[#AAA]': title !== item.title,
-                },
-              )}
+          <li key={item.title}>
+            <Link
+              href={`${!isMenu ? '?' : `${path}${menu}&`}title=${item.title}&category=${defaultCategory(
+                item.title,
+              )}`}
             >
-              {item.title}
-            </li>
-          </Link>
+              <div
+                className={cn(
+                  'cursor-pointer rounded-[83px] px-[16px] py-[8px] text-[#fff]',
+                  {
+                    'bg-black text-white mo:rounded-none mo:border-2 mo:border-x-0 mo:border-t-0 mo:border-black mo:bg-white mo:text-black':
+                      title === item.title,
+                    'bg-white text-[#AAA]': title !== item.title,
+                  },
+                )}
+              >
+                {item.title}
+              </div>
+            </Link>
+          </li>
         ))}
       </ul>
       <ul
@@ -66,21 +69,23 @@ export default function CategoryPicker({
               : `?title=${title}&category=${item}`
 
             return (
-              <Link href={link} key={item}>
-                <li
-                  className={cn(
-                    'flex h-[39px] min-w-[60px] cursor-pointer items-center justify-center text-nowrap border-[3px] font-[600]',
-                    'mo:rounded-[100px] mo:px-[14px] mo:py-[10px] mo:text-[12px] mo:font-[500] mo:text-white',
-                    {
-                      'border-x-0 border-t-0 border-b-[#000] mo:bg-black':
-                        category === item,
-                      'border-0 mo:bg-[#AEAEAE]': category !== item,
-                    },
-                  )}
-                >
-                  {item}
-                </li>
-              </Link>
+              <li key={item}>
+                <Link href={link}>
+                  <div
+                    className={cn(
+                      'flex h-[39px] min-w-[60px] cursor-pointer items-center justify-center text-nowrap border-[3px] font-[600]',
+                      'mo:rounded-[100px] mo:px-[14px] mo:py-[10px] mo:text-[12px] mo:font-[500] mo:text-white',
+                      {
+                        'border-x-0 border-t-0 border-b-[#000] mo:bg-black':
+                          category === item,
+                        'border-0 mo:bg-[#AEAEAE]': category !== item,
+                      },
+                    )}
+                  >
+                    {item}
+                  </div>
+                </Link>
+              </li>
             )
           })}
       </ul>

--- a/src/app/_components/modal/index.tsx
+++ b/src/app/_components/modal/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { cn } from '@/app/_utils/twMerge'
-import { ReactNode } from 'react'
+import { ReactNode, useEffect } from 'react'
 
 type ModalProps = {
   children: ReactNode
@@ -14,6 +14,14 @@ function Modal({
   innerClassNames,
   children,
 }: ModalProps) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = 'auto'
+    }
+  }, [])
+
   return (
     <div
       id="ModalContainer"

--- a/src/app/_components/modalContainer/index.tsx
+++ b/src/app/_components/modalContainer/index.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { modalsState } from '@/app/_atoms/modalState'
+import { useRecoilValue } from 'recoil'
+
+function ModalContainer() {
+  const modals = useRecoilValue(modalsState)
+
+  return (
+    <>
+      {modals.map((modal, index) => {
+        const { Component, props } = modal
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={index} className="modal">
+            <Component {...props} />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export default ModalContainer

--- a/src/app/_components/potal/index.tsx
+++ b/src/app/_components/potal/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 interface PropsType {
@@ -7,8 +7,11 @@ interface PropsType {
 }
 
 export default function Portal({ title, children }: PropsType) {
-  const el = document.createElement('div')
-  el.id = title
+  const [el] = useState(() => {
+    const element = document.createElement('div')
+    element.id = title
+    return element
+  })
 
   useEffect(() => {
     document.body.appendChild(el)
@@ -16,7 +19,7 @@ export default function Portal({ title, children }: PropsType) {
     return () => {
       document.body.removeChild(el)
     }
-  })
+  }, [el])
 
   return createPortal(children, el)
 }

--- a/src/app/_components/potal/index.tsx
+++ b/src/app/_components/potal/index.tsx
@@ -1,0 +1,22 @@
+import { ReactNode, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+interface PropsType {
+  title: string
+  children: ReactNode
+}
+
+export default function Portal({ title, children }: PropsType) {
+  const el = document.createElement('div')
+  el.id = title
+
+  useEffect(() => {
+    document.body.appendChild(el)
+
+    return () => {
+      document.body.removeChild(el)
+    }
+  })
+
+  return createPortal(children, el)
+}

--- a/src/app/_hook/api/votes/index.ts
+++ b/src/app/_hook/api/votes/index.ts
@@ -5,4 +5,5 @@ export const voteKeys = createQueryKeys('votes', {
   favorites: (folderId: number) => [folderId],
   voteList: (hobby: string, sortOption: string) => [hobby, sortOption],
   voteRanking: (hobby: string) => [hobby],
+  folderList: null,
 })

--- a/src/app/_hook/api/votes/queries/useFavoritesList.ts
+++ b/src/app/_hook/api/votes/queries/useFavoritesList.ts
@@ -1,15 +1,18 @@
-import { getServerCookie } from '@/app/_utils/serverCookie'
+import { useClientCookies } from '@/app/_hook/common/useClientCookies'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { voteKeys } from '..'
 
 interface RequestInfo {
   type: 'folder' | 'item'
   folderId?: number | null
+  accessToken: string
 }
 
-export async function fetchFavoriteList({ type, folderId }: RequestInfo) {
-  const accessToken = await getServerCookie('accessToken')
-
+export async function fetchFavoriteList({
+  type,
+  folderId,
+  accessToken,
+}: RequestInfo) {
   let url = `${process.env.NEXT_PUBLIC_BASE_URL}/api/favorites?favoriteTypeCondition=${type}`
 
   if (type === 'item' && folderId) {
@@ -38,9 +41,12 @@ export const useFavoritesList = (
   type: 'folder' | 'item',
   folderId?: number | null,
 ) => {
+  const { getClientCookie } = useClientCookies()
+  const accessToken = getClientCookie('accessToken')
+
   const { data: itemList } = useSuspenseQuery({
     queryKey: voteKeys.favorites(folderId as number).queryKey,
-    queryFn: () => fetchFavoriteList({ type, folderId }),
+    queryFn: () => fetchFavoriteList({ type, folderId, accessToken }),
     staleTime: 1000 * 60,
   })
 

--- a/src/app/_hook/api/votes/queries/useFolderList.ts
+++ b/src/app/_hook/api/votes/queries/useFolderList.ts
@@ -1,0 +1,17 @@
+import { useClientCookies } from '@/app/_hook/common/useClientCookies'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { voteKeys } from '..'
+import { fetchFavoriteList } from './useFavoritesList'
+
+export const useFolderList = (type: 'folder' | 'item') => {
+  const { getClientCookie } = useClientCookies()
+  const accessToken = getClientCookie('accessToken')
+
+  const { data: folderList } = useSuspenseQuery({
+    queryKey: voteKeys.folderList.queryKey,
+    queryFn: () => fetchFavoriteList({ type, accessToken }),
+    staleTime: 1000 * 60,
+  })
+
+  return { folderList }
+}

--- a/src/app/_hook/common/useModal.ts
+++ b/src/app/_hook/common/useModal.ts
@@ -1,0 +1,23 @@
+import { ModalComponentProps, modalsState } from '@/app/_atoms/modalState'
+import { useRecoilState } from 'recoil'
+
+export const useModals = () => {
+  const [modals, setModals] = useRecoilState<ModalComponentProps[]>(modalsState)
+
+  const open = <P>(Component: React.FC<P>, props?: P) => {
+    setModals((prevModals) => [
+      ...prevModals,
+      { Component, props } as ModalComponentProps,
+    ])
+  }
+
+  const close = () => {
+    setModals((prevModals) => prevModals.slice(0, -1))
+  }
+
+  return {
+    modals,
+    open,
+    close,
+  }
+}

--- a/src/app/_utils/dateFormatter.ts
+++ b/src/app/_utils/dateFormatter.ts
@@ -5,6 +5,7 @@ export function dateFormatter(dateString: string): string {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
+    timeZone: 'UTC',
   }).format(date)
 
   return formattedDate
@@ -22,6 +23,7 @@ export function detailDateFormatter(dateString: string): string {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
+    timeZone: 'UTC',
   }
 
   const formattedDate = new Intl.DateTimeFormat('ko-KR', options).format(date)


### PR DESCRIPTION
## 1. Changes

### 1. 투표 페이지 태그 변경 작업

### 2. 투표 아이템 선택 상태, (투표 아이템 선택 시) 아이템 title, imageUrl 전역 상태 관리

### 3. (투표 아이템 선택 모달 클릭 시) 찜 목록 리스트 사전 캐싱 작업 추가
기존에는 아이템 선택 버튼(모달 open) 클릭 시 폴더 리스트 데이터 Fetching을 시작해 지연 시간 발생했는데,
투표 등록 페이지로 이동된 시점에 미리 폴더 리스트 데이터를 Fetching 하고 캐싱 하여 지연 없이 폴더 리스트 데이터 렌더링

<br/> 

### 캐싱 전 (폴더 리스트 데이터 화면 노출 지연 발생)
![화면-기록-2024-06-01-오후-3 14 07](https://github.com/uju-in/lime-frontend/assets/114549939/1d937010-dbd9-4c04-a276-60a285367adf)

### 캐싱 후
![화면-기록-2024-06-01-오후-3 11 28](https://github.com/uju-in/lime-frontend/assets/114549939/98a2255c-ab7e-40fa-8457-c534e78283f1)

**관련 커밋**
- 18ce2475651175fae2288f51ce8a685b4d630dae

<br/>

### 4. 모달 활성화 시 배경(body) 스크롤 제거 작업
- c312dbf5460cca87dd658bdcacb0a09a00e50f59

<br/>

### 5. 모달 open/close 전역 상태 관리
다른 모달 기능에서도 공통으로 사용 가능하기 때문에 추후에 리팩토링 시 사용하면 좋을 것 같습니다.

<br/>

**관련 커밋**
- a398fcf3cef343c46fcfe5f111f767ce249a9f9a

<br/>

### 6. React Portal 적용
모달은 일반적으로 화면 전체를 덮는 오버레이로, 페이지의 최상위 레벨에 위치하는 것이 의미적이지만,
모달 컴포넌트가 부모 컴포넌트의 DOM 노드 안에 중첩되어 있으면, HTML 구조가 복잡해지고, 
모달이 다른 모든 요소 위에 위치해야 한다는 의미가 명확하지 않게 됨.

-> Portal 적용으로, 모달 컴포넌트를 렌더링할 때 최상위 DOM 노드에 직접 삽입해 HTML 구조를 간결하고 직관적으로 유지, 모달이 다른 모든 요소 위에 표시된다는 의미를 명확하게 전달

<br/>

- `createPortal`함수만 사용해 Portal를 구현하지 않고 Portal 컴포넌트를 따로 만든 이유는 모달이 `unmount` 될 때, 해당 노드를 직접 정리하는 코드를 추가하기 위함입니다!

<br/>

**참고**
- [React 포털의 힘 이해: 심층 분석](https://www.dhiwise.com/post/understanding-the-power-of-react-portals-an-in-depth-analysis)

<br/>

## 2. Screenshot
## 3. Issues

### 1. (투표 아이템 선택 모달 클릭 시) 찜 목록 리스트 사전 캐싱 작업 같은 경우,
투표 등록 페이지에 접속 -> 높은 확률로 아이템 선택 모달 사용으로 전환될 것 같아서,
페이지에 접속했을 때 캐싱을 진해해도 괜찮겠다고 생각했는데,
혹시 다른 의견 있으시다면 피드백 부탁드립니다!

<br/>

## 4. To Reviewer

- @yeeeerim 
모달 관련 작업 같은 경우 문제가 없다면, 다른 기능에도 사용하면 좋을 것 같습니다!
`1. Changes` 위주로 확인 부탁드립니다!

<br/>

## 5. Plans
- 아이템 상세 & 리뷰

<br/>